### PR TITLE
staging

### DIFF
--- a/admin/applications/__init__.py
+++ b/admin/applications/__init__.py
@@ -178,20 +178,14 @@ def download(reference_number):
         db.session.commit()
 
         from grc.utils.application_files import ApplicationFiles
-        bytes, file_name = ApplicationFiles().create_or_download_pdf(
-            application.reference_number,
-            application.application_data(),
-            download=True,
-            create_toc=False,
-            paginate=False
-        )
+        bytes_, file_name = ApplicationFiles().create_pdf_admin_with_files_attached(application.application_data())
 
         logger.log(LogLevel.INFO, f"{logger.mask_email_address(session['signedIn'])} downloaded application {reference_number}")
 
-        if bytes is None:
+        if bytes_ is None:
             return abort(404)
 
-        response = make_response(bytes)
+        response = make_response(bytes_)
         response.headers.set('Content-Type', 'application/pdf')
         response.headers.set('Content-Disposition', 'attachment', filename=file_name)
         return response

--- a/deploy/staging/app-deployment.yaml
+++ b/deploy/staging/app-deployment.yaml
@@ -58,8 +58,6 @@ spec:
                 key: govuk-pay-api-key
           - name: LOG_LEVEL
             value: DEBUG
-          - name: NOTIFY_OVERRIDE_EMAIL
-            value: ivan.touloumbadjian@hmcts.net
           - name: NOTIFY_API
             valueFrom:
               secretKeyRef:

--- a/grc/submit_and_pay/__init__.py
+++ b/grc/submit_and_pay/__init__.py
@@ -155,14 +155,9 @@ def checkYourAnswers():
 def download():
     application_data = DataStore.load_application_by_session_reference_number()
 
-    bytes, file_name = ApplicationFiles().create_or_download_pdf(
-        application_data.reference_number,
-        application_data,
-        is_admin=False,
-        download=True
-    )
+    bytes_, file_name = ApplicationFiles().create_pdf_public(application_data)
 
-    response = make_response(bytes)
+    response = make_response(bytes_)
     response.headers.set('Content-Type', 'application/pdf')
     response.headers.set('Content-Disposition', 'attachment', filename=file_name)
     return response
@@ -207,16 +202,10 @@ def confirmation():
 
     @copy_current_request_context
     def create_files(reference_number, application_data_):
-        ApplicationFiles().create_and_upload_attachments(
-            reference_number,
-            application_data_,
-        )
-        ApplicationFiles().create_or_download_pdf(
-            reference_number,
-            application_data_
-        )
-
-        mark_files_created(reference_number)
+        app_files_util = ApplicationFiles()
+        if app_files_util.create_and_upload_attachments(reference_number, application_data_) and \
+                app_files_util.upload_pdf_admin_with_file_names_attached(application_data_):
+            mark_files_created(reference_number)
 
     threading.Thread(target=create_files, args=[application_data.reference_number, application_data]).start()
 

--- a/tests/grc/unit/utils/test_application_files/test_create_or_download_pdf.py
+++ b/tests/grc/unit/utils/test_application_files/test_create_or_download_pdf.py
@@ -1,0 +1,178 @@
+import io
+import fitz
+import pytest
+from grc.utils.application_files import ApplicationFiles
+from unittest.mock import patch, MagicMock
+
+
+class TestCreateOrCreateDownloadPDF:
+
+    @pytest.fixture()
+    def app_files(self):
+        yield ApplicationFiles()
+
+    @staticmethod
+    def mock_create_coversheet(*args, **kwargs):
+        bytes_buffer = io.BytesIO()
+        pdf_document = fitz.open()
+        content_page = pdf_document.new_page(width=595, height=842)
+        content_page.insert_text((100, 100), f"Coversheet", fontsize=12)
+        pdf_document.save(bytes_buffer)
+        bytes_buffer.seek(0)
+        return bytes_buffer
+
+    @staticmethod
+    def mock_create_output_pdf_document_files_attached(*args, **kwargs):
+        bytes_buffer = io.BytesIO()
+        pdf_document = fitz.open()
+        try:
+            coversheet = fitz.open(stream=args[1][0], filetype='pdf')
+            pdf_document.insert_pdf(coversheet)
+        except IndexError:
+            pass
+        content_page = pdf_document.new_page(width=595, height=842)
+        content_page.insert_text((100, 100), f"PDF with application data and attached files", fontsize=12)
+        pdf_document.save(bytes_buffer)
+        bytes_buffer.seek(0)
+        return bytes_buffer
+
+    @staticmethod
+    def mock_create_output_pdf_document_with_filenames(*args, **kwargs):
+        bytes_buffer = io.BytesIO()
+        pdf_document = fitz.open()
+        try:
+            coversheet = fitz.open(stream=args[1][0], filetype='pdf')
+            pdf_document.insert_pdf(coversheet)
+        except IndexError:
+            pass
+        content_page = pdf_document.new_page(width=595, height=842)
+        content_page.insert_text((100, 100), f"PDF with application data with uploaded file names", fontsize=12)
+        pdf_document.save(bytes_buffer)
+        bytes_buffer.seek(0)
+        return bytes_buffer
+
+    @staticmethod
+    def mock_attach_files_method(pdfs, *args):
+        for i in range(1, 4):
+            bytes_buffer = io.BytesIO()
+            pdf_document = fitz.open()
+            content_page = pdf_document.new_page(width=595, height=842)
+            content_page.insert_text((100, 100), f"Uploaded doc {i} to attach to application pdf", fontsize=12)
+            pdf_document.save(bytes_buffer)
+            bytes_buffer.seek(0)
+            pdfs.append(bytes_buffer)
+
+    @staticmethod
+    def mock_attach_filenames_method(sections, *args):
+        bytes_buffer = io.BytesIO()
+        pdf_document = fitz.open()
+        content_page = pdf_document.new_page(width=595, height=842)
+        text = ''
+        for section in sections:
+            text += f'{section}\n'
+            for i in range(1, 3):
+                text += f'Uploaded doc {i} for section {section} to attach to application pdf\n'
+        content_page.insert_text((100, 100), text, fontsize=12)
+        pdf_document.save(bytes_buffer)
+        bytes_buffer.seek(0)
+        return bytes_buffer
+
+    @patch('grc.utils.application_files.AwsS3Client')
+    def test_download_pdf_admin(self, mock_s3_client: MagicMock, app_files, test_application):
+        download_object_mock: MagicMock = mock_s3_client.return_value.download_object
+        download_object_mock.return_value = io.BytesIO('test application pdf'.encode('utf-8'))
+        assert app_files.download_pdf_admin(test_application.application_data()) == b'test application pdf'
+        download_object_mock.assert_called_once_with('ABCD1234.pdf')
+
+    @patch('grc.utils.application_files.AwsS3Client')
+    def test_download_pdf_admin_file_not_found(self, mock_s3_client: MagicMock, app_files, test_application):
+        download_object_mock: MagicMock = mock_s3_client.return_value.download_object
+        download_object_mock.return_value = None
+        assert app_files.download_pdf_admin(test_application.application_data()) is None
+        download_object_mock.assert_called_once_with('ABCD1234.pdf')
+
+    @patch('grc.utils.application_files.ApplicationFiles.attach_all_files')
+    def test_create_pdf_attach_files(self, mock_attach_files: MagicMock, app_files, test_application):
+        mock_attach_files.side_effect = self.mock_attach_files_method
+        pdf_data = app_files._create_pdf_attach_files(test_application.application_data(), [], app_files.sections)
+        pdf_document = fitz.open(stream=pdf_data)
+        page_1, page_2, page_3 = pdf_document
+        assert 'Uploaded doc 1 to attach to application pdf' in page_1.get_text()
+        assert 'Uploaded doc 2 to attach to application pdf' in page_2.get_text()
+        assert 'Uploaded doc 3 to attach to application pdf' in page_3.get_text()
+        pdf_document.close()
+
+    @patch('grc.utils.application_files.ApplicationFiles.create_attachment_names_pdf')
+    def test_create_pdf_attach_filenames(self, mock_attach_filenames: MagicMock, app_files, test_application):
+        mock_attach_filenames.side_effect = self.mock_attach_filenames_method
+        test_sections = ['statutoryDeclarations', 'marriageDocuments', 'nameChange']
+        pdf_data = app_files._create_pdf_attach_filenames(test_application.application_data(), [], test_sections)
+        pdf_document = fitz.open(stream=pdf_data)
+        page_with_filenames = pdf_document[0].get_text()
+        assert 'statutoryDeclarations' in page_with_filenames
+        assert 'Uploaded doc 1 for section statutoryDeclarations to attach to application pdf' in page_with_filenames
+        assert 'Uploaded doc 2 for section statutoryDeclarations to attach to application pdf' in page_with_filenames
+        assert 'marriageDocuments' in page_with_filenames
+        assert 'Uploaded doc 1 for section marriageDocuments to attach to application pdf' in page_with_filenames
+        assert 'Uploaded doc 2 for section marriageDocuments to attach to application pdf' in page_with_filenames
+        assert 'nameChange' in page_with_filenames
+        assert 'Uploaded doc 1 for section nameChange to attach to application pdf' in page_with_filenames
+        assert 'Uploaded doc 2 for section nameChange to attach to application pdf' in page_with_filenames
+        pdf_document.close()
+
+    @patch('grc.utils.application_files.ApplicationFiles._create_pdf_attach_files')
+    @patch('grc.utils.application_files.ApplicationFiles.create_application_cover_sheet_pdf')
+    def test_create_pdf_public(self, mock_create_coversheet: MagicMock, mock_pdf_attach_files: MagicMock, app_files,
+                               test_application):
+        mock_create_coversheet.return_value = self.mock_create_coversheet()
+        mock_pdf_attach_files.side_effect = self.mock_create_output_pdf_document_files_attached
+        pdf, filename = app_files.create_pdf_public(test_application.application_data())
+        assert filename == 'grc_test_public_email_example_com.pdf'
+        pdf_document = fitz.open(stream=pdf)
+        page_1, page_2 = pdf_document
+        assert 'Coversheet' in page_1.get_text()
+        assert 'PDF with application data and attached files' in page_2.get_text()
+        pdf_document.close()
+
+    @patch('grc.utils.application_files.ApplicationFiles._create_pdf_attach_files')
+    @patch('grc.utils.application_files.ApplicationFiles.create_application_cover_sheet_pdf')
+    def test_create_pdf_admin_with_files_attached(self, mock_create_coversheet: MagicMock,
+                                                  mock_pdf_attach_files: MagicMock, app_files, test_application):
+        mock_create_coversheet.return_value = self.mock_create_coversheet()
+        mock_pdf_attach_files.side_effect = self.mock_create_output_pdf_document_files_attached
+        pdf, filename = app_files.create_pdf_admin_with_files_attached(test_application.application_data())
+        assert filename == 'ABCD1234.pdf'
+        pdf_document = fitz.open(stream=pdf)
+        page_1, page_2 = pdf_document
+        assert 'Coversheet' in page_1.get_text()
+        assert 'PDF with application data and attached files' in page_2.get_text()
+        pdf_document.close()
+
+    @patch('grc.utils.application_files.ApplicationFiles._create_pdf_attach_filenames')
+    @patch('grc.utils.application_files.ApplicationFiles.create_application_cover_sheet_pdf')
+    def test_create_pdf_admin_with_filenames(self, mock_create_coversheet: MagicMock,
+                                             mock_pdf_attach_filenames: MagicMock, app_files, test_application):
+        mock_create_coversheet.return_value = self.mock_create_coversheet()
+        mock_pdf_attach_filenames.side_effect = self.mock_create_output_pdf_document_with_filenames
+        pdf, filename = app_files.create_pdf_admin_with_filenames(test_application.application_data())
+        assert filename == 'ABCD1234.pdf'
+        pdf_document = fitz.open(stream=pdf)
+        page_1, page_2 = pdf_document
+        assert 'Coversheet' in page_1.get_text()
+        assert 'PDF with application data with uploaded file names' in page_2.get_text()
+        pdf_document.close()
+
+    @patch('grc.utils.application_files.ApplicationFiles.create_pdf_admin_with_filenames')
+    @patch('grc.utils.application_files.AwsS3Client')
+    def test_upload_pdf_admin_with_file_names_attached(self, mock_s3_client: MagicMock, mock_create_pdf: MagicMock,
+                                                       app_files, test_application):
+        upload_object_mock: MagicMock = mock_s3_client.return_value.upload_fileobj
+        upload_object_mock.return_value = True
+        mock_application_pdf_to_upload = self.mock_create_output_pdf_document_with_filenames()
+        mock_create_pdf.return_value = mock_application_pdf_to_upload
+        assert app_files.upload_pdf_admin_with_file_names_attached(test_application.application_data()) is True
+        upload_object_mock.assert_called_once_with(mock_application_pdf_to_upload, 'ABCD1234.pdf')
+
+
+
+


### PR DESCRIPTION
* RST 6524 initial commit prep test data for unit tests

* add app files helpers to generate test uploads data

* add app files helpers to generate test uploads data

* refactor upload helper and tests for getting docs with section

* start ut for create or download and add test data files and mock s3 client

* remove unused import and fixture

* mock upload file s3 client in test upload helper

* add logs to create or download attachments

* ignore tests temp

* revert config fixture change

* revert admin download check condition

* amend mock download object and save method calls input

* add test to check correct files are downloaded

* create test aws client helper

* assert download objects called including original file names

* rename test

* add logging

* revert application files util to mirror staging

* test new create zip function

* add test for uploading zip file to s3

* begin writing test for download attachment

* amend mock s3 client to cater for upload and no zip file exists

* amend return type for download attachments

* add test for download zip doesn't exist

* run tests in build

* fix tests for get files for section tests

* mark zip files method as internal

* mark zip files method as internal

* amend submission and download attachments to use correct methods

* remove now redundandt create_or_download method and mark get methods as internal

* RST-6579 refactor create or download util into more legible methods

* amend old usage of old util to use new specific utils

* amend old usage of old util to use new specific utils

* reorder internal methods

* add tests for all new aspects of pdf download and upload

* assert mock upload function call with args