### PR TITLE
Staging

### DIFF
--- a/grc/upload/__init__.py
+++ b/grc/upload/__init__.py
@@ -107,7 +107,7 @@ def resize_image(document):
     try:
         img = Image.open(document)
 
-        #To use Image.Resampling.LANCZOS, image must be RBG
+        #To use JPEG, image must be RBG
         if img.mode in ("RGBA", "P"):
             logger.log(LogLevel.INFO, "Image changed from RBGA to RBG")
             img = img.convert("RGB")

--- a/grc/utils/application_files.py
+++ b/grc/utils/application_files.py
@@ -43,10 +43,12 @@ class ApplicationFiles:
                         zipper.writestr(attachment_file_name, data.getvalue())
 
                     file_name, file_ext = self.get_filename_and_extension(evidence_file.aws_file_name)
-                    if file_ext.lower() in ['.jpg', '.jpeg', '.png', '.tif', '.tiff', '.bmp']:
-                        data = AwsS3Client().download_object(f'{file_name}_original{file_ext}')
+                    original_file_name, original_file_ext = self.get_filename_and_extension(evidence_file.original_file_name)
+                    if original_file_ext.lower() in ['.jpg', '.jpeg', '.png', '.tif', '.tiff', '.bmp']:
+                        data = AwsS3Client().download_object(f'{file_name}_original{original_file_ext}')
+                        logger.log(LogLevel.DEBUG, '*********************')
+                        logger.log(LogLevel.DEBUG, data)
                         if data is not None:
-                            logger.log(LogLevel.INFO,f'Adding original file: {file_name}_original{file_ext} to zip.')
                             file_name, file_ext = self.get_filename_and_extension(evidence_file.original_file_name)
                             attachment_file_name = (f"{application_data.reference_number}__{section}__"
                                                     f"{(file_index + 1)}_{file_name}_original{file_ext}")

--- a/grc/utils/application_files.py
+++ b/grc/utils/application_files.py
@@ -46,8 +46,6 @@ class ApplicationFiles:
                     original_file_name, original_file_ext = self.get_filename_and_extension(evidence_file.original_file_name)
                     if original_file_ext.lower() in ['.jpg', '.jpeg', '.png', '.tif', '.tiff', '.bmp']:
                         data = AwsS3Client().download_object(f'{file_name}_original{original_file_ext}')
-                        logger.log(LogLevel.DEBUG, '*********************')
-                        logger.log(LogLevel.DEBUG, data)
                         if data is not None:
                             file_name, file_ext = self.get_filename_and_extension(evidence_file.original_file_name)
                             attachment_file_name = (f"{application_data.reference_number}__{section}__"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RST-6966

**Problem:**

When a user uploads their files for evidence in the application, it uploads them to an aws s3 bucket. This upload includes two files: 
- a newly resized image with jpg extension like "{original_file_name}.jpg".
- a file with "_original" at the end and its original file extension "{original_file_name}_orignal.{original_file_extension}".
It also saves the file name and original file name to a class so we can access these later.

Once the user finishes their application and pays, we access the the file name and original file name from that class. We use these file names so we can download the files from the s3 bucket and then place them in a zip folder. An admin user will then download this zip folder.

The issue was that, when a user opened the zip file - there were some files that had _original and some that didn't.

The technical issue was that: when we were downloading the _original file from our s3 bucket, we were using the the new files file extension; the new file's file extension is always a jpg. This means it would try download "{original_file_name}_original.jpg", which wouldn't exist unless the original file extension was a jpg in the first place.

So some files would download with a an _original file like they're supposed to because the file has a jpg extension, but any other file without a jpg extension would not have this _original file.

**Solution:**

Had to update some functions like:
- Image.Resampling.LANCZOS 
- img = img.convert("RGB")
Because the resize_image function would fail meaning _original file wouldn't be created

Before: 
data = AwsS3Client().download_object(f'{file_name}_original{file_ext}')

After:
data = AwsS3Client().download_object(f'{file_name}_original{original_file_ext}')

Now when we download object we use original file_extension, the var file_ext would always be jpg so this needed to change. After testing on preprod, this works and all files are downloaded with _original.
