### PR TITLE
TPET-834 Make contact email mandatory

### DIFF
--- a/admin/glimr/glimr_new_case.py
+++ b/admin/glimr/glimr_new_case.py
@@ -108,7 +108,7 @@ class GlimrNewCase:
         return str(self.personal_details.title) + " " + str(self.personal_details.last_name)
 
     def get_contact_preference(self) -> Optional[str]:
-        if self.personal_details.contact_email_address:
+        if self.personal_details.contact_by_email:
             return 'Email'
         if self.personal_details.contact_phone_number:
             return 'Phone Call'

--- a/grc/business_logic/data_structures/personal_details_data.py
+++ b/grc/business_logic/data_structures/personal_details_data.py
@@ -64,6 +64,7 @@ class PersonalDetailsData:
         self.address_postcode: str = None
 
         self.contact_email_address: str = None
+        self.contact_by_email: bool = None
         self.contact_phone_number: str = None
         self.contact_by_post: bool = None  # We take the postal address from the address fields above
 

--- a/grc/personal_details/__init__.py
+++ b/grc/personal_details/__init__.py
@@ -187,14 +187,12 @@ def contactPreferences():
     application_data = DataStore.load_application_by_session_reference_number()
 
     if request.method == 'POST':
-        if 'EMAIL' not in form.contact_options.data:
-            form.email.data = None
         if 'PHONE' not in form.contact_options.data:
             form.phone.data = None
 
         if form.validate_on_submit():
-            application_data.personal_details_data.contact_email_address = \
-                form.email.data if 'EMAIL' in form.contact_options.data else ''
+            application_data.personal_details_data.contact_email_address = form.email.data
+            application_data.personal_details_data.contact_by_email = ('EMAIL' in form.contact_options.data)
             application_data.personal_details_data.contact_phone_number = \
                 form.phone.data if 'PHONE' in form.contact_options.data else ''
             application_data.personal_details_data.contact_by_post = ('POST' in form.contact_options.data)
@@ -204,7 +202,7 @@ def contactPreferences():
 
     if request.method == 'GET':
         form.contact_options.data = []
-        if application_data.personal_details_data.contact_email_address:
+        if application_data.personal_details_data.contact_by_email:
             form.contact_options.data.append('EMAIL')
         if application_data.personal_details_data.contact_phone_number:
             form.contact_options.data.append('PHONE')

--- a/grc/personal_details/forms.py
+++ b/grc/personal_details/forms.py
@@ -314,8 +314,10 @@ class ContactPreferencesForm(FlaskForm):
     )
 
     email = EmailField(
-        validators=[StrictRequiredIf('contact_options', 'EMAIL', message=c.NO_EMAIL_ADDRESS_ERROR,
-                                     validators=[LazyEmail(lazy_message=c.EMAIL_ADDRESS_INVALID_ERROR)])]
+        validators=[
+            LazyDataRequired(lazy_message=c.NO_EMAIL_ADDRESS_ERROR),
+            LazyEmail(lazy_message=c.EMAIL_ADDRESS_INVALID_ERROR)
+        ]
     )
 
     phone = TelField(

--- a/grc/templates/personal-details/contact-preferences.html
+++ b/grc/templates/personal-details/contact-preferences.html
@@ -34,17 +34,6 @@
                     checkboxesOptions={
                         'questionIsPageHeading': true,
                         'conditionalOptions': [
-                            ('EMAIL',
-                            textInput.renderFor(
-                                form,
-                                fieldName='email',
-                                textInputForOptions={
-                                    'labelOptions': { 'htmlOrText': _('Email address') },
-                                    'classes': 'govuk-input--width-20',
-                                    'autocomplete': 'email',
-                                    'attributes': [ ('spellcheck', 'false') ]
-                                }
-                            )),
                             ('PHONE',
                             textInput.renderFor(
                                 form,
@@ -58,6 +47,17 @@
                             )),
                             ('POST', postHtmlBlock())
                         ]
+                    }
+                ) }}
+
+                {{ textInput.renderFor(
+                    form,
+                    fieldName='email',
+                    textInputForOptions={
+                        'labelOptions': { 'htmlOrText': _('Email address') },
+                        'classes': 'govuk-input--width-20',
+                        'autocomplete': 'email',
+                        'attributes': [ ('spellcheck', 'false') ]
                     }
                 ) }}
 

--- a/tests/end_to_end_tests/journey_1/personal_details/section.py
+++ b/tests/end_to_end_tests/journey_1/personal_details/section.py
@@ -694,11 +694,11 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.url('/personal-details/contact-preferences')
     await asserts.accessibility()
     await asserts.h1('How would you like to be contacted if we have any questions about your application?')
-    await asserts.number_of_errors(1)
+    await asserts.number_of_errors(2)
     await asserts.error(field='contact_options', message="Select how would you like to be contacted")
+    await asserts.error(field='email', message="Enter your email address")
 
-    # Choose "Email" and "Phone" options, but don't enter an email address or phone number
-    await helpers.check_checkbox(field='contact_options', value='EMAIL')
+    # Choose "Phone" option, but don't enter an email address or phone number
     await helpers.check_checkbox(field='contact_options', value='PHONE')
     await helpers.click_button('Save and continue')
     await asserts.url('/personal-details/contact-preferences')
@@ -709,9 +709,9 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.error(field='phone', message="Enter your phone number")
 
     # Enter an invalid email address
-    await helpers.check_checkbox(field='contact_options', value='EMAIL')
     await helpers.fill_textbox(field='email', value='inv@lid.email.@ddress')
     await helpers.uncheck_checkbox(field='contact_options', value='PHONE')
+    await helpers.check_checkbox(field='contact_options', value='POST')
     await helpers.click_button('Save and continue')
     await asserts.url('/personal-details/contact-preferences')
     await asserts.accessibility()
@@ -720,9 +720,10 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.error(field='email', message="Enter a valid email address")
 
     # Enter an invalid phone number
+    await helpers.fill_textbox(field='email', value=data.EMAIL_ADDRESS)
     await helpers.check_checkbox(field='contact_options', value='PHONE')
     await helpers.fill_textbox(field='phone', value='310-9320-913209-34433434')
-    await helpers.uncheck_checkbox(field='contact_options', value='EMAIL')
+    await helpers.uncheck_checkbox(field='contact_options', value='POST')
     await helpers.click_button('Save and continue')
     await asserts.url('/personal-details/contact-preferences')
     await asserts.accessibility()

--- a/tests/grc/integration/personal_details/test_contact_preferences.py
+++ b/tests/grc/integration/personal_details/test_contact_preferences.py
@@ -1,0 +1,96 @@
+from tests.grc.integration.conftest import save_test_data, load_test_data
+
+
+def prepare_personal_details_data(test_application):
+    data = test_application.application_data()
+    data.personal_details_data.address_line_one = '1 Test Street'
+    data.personal_details_data.address_town_city = 'London'
+    data.personal_details_data.address_country = 'United Kingdom'
+    data.personal_details_data.address_postcode = 'SW1H 9AJ'
+    save_test_data(data)
+
+
+def log_in(client, test_application):
+    with client.session_transaction() as session:
+        session['reference_number'] = test_application.reference_number
+        session['identity_verified'] = True
+
+
+class TestContactPreferences:
+
+    def test_contact_preferences_post_without_email(self, app, client, test_application):
+        with app.app_context():
+            prepare_personal_details_data(test_application)
+            log_in(client, test_application)
+
+            response = client.post('/personal-details/contact-preferences', data={
+                'contact_options': ['POST']
+            })
+
+            assert response.status_code == 200
+            assert 'Enter your email address' in response.text
+
+    def test_contact_preferences_post_invalid_email(self, app, client, test_application):
+        with app.app_context():
+            prepare_personal_details_data(test_application)
+            log_in(client, test_application)
+
+            response = client.post('/personal-details/contact-preferences', data={
+                'contact_options': ['POST'],
+                'email': 'not-an-email'
+            })
+
+            assert response.status_code == 200
+            assert 'Enter a valid email address' in response.text
+
+    def test_contact_preferences_post_post_only_saves_email_and_post_preference(self, app, client, test_application):
+        with app.app_context():
+            prepare_personal_details_data(test_application)
+            log_in(client, test_application)
+
+            response = client.post('/personal-details/contact-preferences', data={
+                'contact_options': ['POST'],
+                'email': 'alex.example@example.com'
+            })
+            test_app_data = load_test_data(test_application.reference_number)
+
+            assert response.status_code == 302
+            assert response.location == '/personal-details/hmrc'
+            assert test_app_data.personal_details_data.contact_email_address == 'alex.example@example.com'
+            assert test_app_data.personal_details_data.contact_phone_number == ''
+            assert not test_app_data.personal_details_data.contact_by_email
+            assert test_app_data.personal_details_data.contact_by_post
+
+    def test_contact_preferences_post_email_preference_is_saved_separately_from_address(self, app, client, test_application):
+        with app.app_context():
+            prepare_personal_details_data(test_application)
+            log_in(client, test_application)
+
+            response = client.post('/personal-details/contact-preferences', data={
+                'contact_options': ['EMAIL', 'PHONE'],
+                'email': 'alex.example@example.com',
+                'phone': '07123456789'
+            })
+            test_app_data = load_test_data(test_application.reference_number)
+
+            assert response.status_code == 302
+            assert test_app_data.personal_details_data.contact_email_address == 'alex.example@example.com'
+            assert test_app_data.personal_details_data.contact_by_email
+            assert test_app_data.personal_details_data.contact_phone_number == '07123456789'
+
+    def test_contact_preferences_get_does_not_select_email_for_saved_email_address(self, app, client, test_application):
+        with app.app_context():
+            prepare_personal_details_data(test_application)
+            data = load_test_data(test_application.reference_number)
+            data.personal_details_data.contact_email_address = 'alex.example@example.com'
+            data.personal_details_data.contact_phone_number = '07123456789'
+            save_test_data(data)
+            log_in(client, test_application)
+
+            response = client.get('/personal-details/contact-preferences')
+
+            assert response.status_code == 200
+            assert 'value="alex.example@example.com"' in response.text
+            assert 'value="EMAIL" class="govuk-checkboxes__input"' in response.text
+            assert 'value="EMAIL" class="govuk-checkboxes__input" checked' not in response.text
+            assert 'value="07123456789"' in response.text

--- a/tests/grc/unit/glimr/test_glimr_contact_preference.py
+++ b/tests/grc/unit/glimr/test_glimr_contact_preference.py
@@ -1,0 +1,41 @@
+from admin.glimr.glimr_new_case import GlimrNewCase
+from grc.business_logic.data_structures.personal_details_data import PersonalDetailsData
+
+
+def _glimr_case_for(personal_details: PersonalDetailsData) -> GlimrNewCase:
+    case = GlimrNewCase.__new__(GlimrNewCase)
+    case.personal_details = personal_details
+    return case
+
+
+class TestGlimrContactPreference:
+
+    def test_email_address_presence_alone_does_not_force_email_preference(self):
+        personal_details = PersonalDetailsData()
+        personal_details.contact_email_address = 'alex.example@example.com'
+        personal_details.contact_by_email = False
+        personal_details.contact_phone_number = '07123456789'
+
+        case = _glimr_case_for(personal_details)
+
+        assert case.get_contact_preference() == 'Phone Call'
+
+    def test_email_preference_returned_when_chosen(self):
+        personal_details = PersonalDetailsData()
+        personal_details.contact_email_address = 'alex.example@example.com'
+        personal_details.contact_by_email = True
+
+        case = _glimr_case_for(personal_details)
+
+        assert case.get_contact_preference() == 'Email'
+
+    def test_post_preference_returned_when_only_post_chosen(self):
+        personal_details = PersonalDetailsData()
+        personal_details.contact_email_address = 'alex.example@example.com'
+        personal_details.contact_by_email = False
+        personal_details.contact_phone_number = ''
+        personal_details.contact_by_post = True
+
+        case = _glimr_case_for(personal_details)
+
+        assert case.get_contact_preference() == 'Post'

--- a/tests/grc/unit/personal_details/test_contact_preferences_form.py
+++ b/tests/grc/unit/personal_details/test_contact_preferences_form.py
@@ -1,0 +1,30 @@
+from grc.personal_details.forms import ContactPreferencesForm
+
+
+class TestContactPreferencesForm:
+
+    def test_email_required_when_email_contact_option_not_selected(self, app):
+        with app.test_request_context():
+            form = ContactPreferencesForm()
+            form.contact_options.data = ['POST']
+
+            assert not form.validate()
+            assert form.errors['email'][0] == 'Enter your email address'
+
+    def test_email_format_validated_when_email_contact_option_not_selected(self, app):
+        with app.test_request_context():
+            form = ContactPreferencesForm()
+            form.contact_options.data = ['POST']
+            form.email.data = 'not-an-email'
+
+            assert not form.validate()
+            assert form.errors['email'][0] == 'Enter a valid email address'
+
+    def test_phone_still_required_when_phone_contact_option_selected(self, app):
+        with app.test_request_context():
+            form = ContactPreferencesForm()
+            form.contact_options.data = ['PHONE']
+            form.email.data = 'alex.example@example.com'
+
+            assert not form.validate()
+            assert form.errors['phone'][0] == 'Enter your phone number'


### PR DESCRIPTION
## TPET-834 — Make contact email mandatory

Jira: https://tools.hmcts.net/jira/browse/TPET-834

### What & why
The applicant **contact email** on the Contact Preferences page
(`/personal-details/contact-preferences`) was only conditionally required —
it was requested only when the user ticked the "Email" contact option.
TPET-834 requires this email to always be collected, validated and available
to the team. (This is the applicant contact email, not the One Login account
email, which is already mandatory.)

### Changes
- **Email is now mandatory and format-validated** on every submit of the
  Contact Preferences page (`forms.py`, `LazyDataRequired` + `LazyEmail`).
- **Email is a standalone, always-visible field** rather than a reveal under
  the "Email" checkbox (`contact-preferences.html`).
- **Preference vs data separation**: previously the "contacted by email"
  preference was inferred from the email address being present. With the
  address now always present, that would force the Email preference for every
  applicant — **including the single `contactPreference` sent to GLiMR**. Added
  `contact_by_email` to `PersonalDetailsData` and:
  - save it from the "Email" checkbox on POST,
  - populate the checkbox from it on GET,
  - use it in `GlimrNewCase.get_contact_preference()`.
- The email address is saved regardless of the chosen contact method.

### Acceptance criteria coverage
- [x] Email field is mandatory in the contact details section
- [x] Submitting without an email shows a validation error
- [x] Submitting an invalid email shows a format error
- [x] A valid email is saved and available to the team (admin view / PDF /
      check-your-answers already surface `contact_email_address`)

### Out of scope / decisions
- No instant/as-you-type validation — GOV.UK guidance is to validate on submit;
  the ticket does not ask for client-side validation.
- No "required" field indicator added — this service marks only *optional*
  fields, per GOV.UK convention.
- No data migration/back-population for in-flight drafts; they are corrected
  when the applicant next visits the page.
- Team-facing surfaces keep displaying the (now always-present) email address;
  no display redesign was performed.

### Testing
- New unit tests: `tests/grc/unit/personal_details/test_contact_preferences_form.py`
- New integration tests: `tests/grc/integration/personal_details/test_contact_preferences.py`
- New GLiMR regression tests: `tests/grc/unit/glimr/test_glimr_contact_preference.py`
- Updated journey 1 E2E: `tests/end_to_end_tests/journey_1/personal_details/section.py`
- Targeted run (unit + integration + GLiMR): **11 passed** locally in Docker.
- Manually verified in the browser: email is always shown and mandatory; the
  Email preference round-trips independently of the saved address.
