### PR TITLE
TPET-831 — Digital birth certificate upload

### DIFF
--- a/admin/templates/applications/application-pdfkit.html
+++ b/admin/templates/applications/application-pdfkit.html
@@ -160,11 +160,17 @@
         <li>I certify that all the information given in this application is correct to the best of my knowledge. I understand that to make a false application is an offence: <strong>{% if application_data.submit_and_pay_data.declaration %}Yes{% else %}No{% endif %}</strong></li>
     </ul>
 
+    {% set needs_to_post_birth_or_adoption_certificate = application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
     <h4 class="gds-family-cs-bold" style="font-size: 21px;">Documents to post</h4>
     <ul class="govuk-list govuk-list--bullet" style="font-size: 19px;margin-left:28px;">
-        <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% if needs_to_post_birth_or_adoption_certificate %}
+            <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% endif %}
         {% if application_data.submit_and_pay_data.is_using_ex160_form %}
             <li>an EX160 form</li>
+        {% endif %}
+        {% if not needs_to_post_birth_or_adoption_certificate and not application_data.submit_and_pay_data.is_using_ex160_form %}
+            <li>None &ndash; all required documents have been uploaded</li>
         {% endif %}
     </ul>
 

--- a/admin/templates/applications/application.html
+++ b/admin/templates/applications/application.html
@@ -160,11 +160,17 @@
         <li>I certify that all the information given in this application is correct to the best of my knowledge. I understand that to make a false application is an offence: <strong>{% if application_data.submit_and_pay_data.declaration %}Yes{% else %}No{% endif %}</strong></li>
     </ul>
 
+    {% set needs_to_post_birth_or_adoption_certificate = application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
     <h4 style="font-size: 16px;">Documents to post</h4>
     <ul class="govuk-list govuk-list--bullet" style="font-size: 16px;">
-        <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% if needs_to_post_birth_or_adoption_certificate %}
+            <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% endif %}
         {% if application_data.submit_and_pay_data.is_using_ex160_form %}
             <li>an EX160 form</li>
+        {% endif %}
+        {% if not needs_to_post_birth_or_adoption_certificate and not application_data.submit_and_pay_data.is_using_ex160_form %}
+            <li>None &ndash; all required documents have been uploaded</li>
         {% endif %}
     </ul>
 

--- a/admin/templates/applications/view-application.html
+++ b/admin/templates/applications/view-application.html
@@ -667,7 +667,7 @@
                 <tbody class="govuk-table__body">
                     {{ summary_list_item(
                         title='Your original or a certified copy (opens in a new tab) of your full birth or adoption certificate',
-                        value=('Yes')
+                        value=('No' if application_data.uploads_data.birth_or_adoption_certificates | length > 0 else 'Yes')
                     ) }}
 
                     {{ summary_list_item(

--- a/grc/business_logic/data_structures/application_data.py
+++ b/grc/business_logic/data_structures/application_data.py
@@ -118,6 +118,10 @@ class ApplicationData:
         return self.is_overseas_application
 
     @property
+    def need_birth_or_adoption_certificate(self) -> bool:
+        return True
+
+    @property
     def section_status_medical_reports(self) -> ListStatus:
         if self.need_medical_reports:
             return self._upload_section_status(self.uploads_data.medical_reports)
@@ -155,6 +159,10 @@ class ApplicationData:
     @property
     def section_status_statutory_declarations(self) -> ListStatus:
         return self._upload_section_status(self.uploads_data.statutory_declarations)
+
+    @property
+    def section_status_birth_or_adoption_certificates(self) -> ListStatus:
+        return self._upload_section_status(self.uploads_data.birth_or_adoption_certificates)
 
     @property
     def section_status_submit_and_pay_data(self) -> ListStatus:

--- a/grc/templates/applications/application.html
+++ b/grc/templates/applications/application.html
@@ -160,11 +160,17 @@
         <li>I certify that all the information given in this application is correct to the best of my knowledge. I understand that to make a false application is an offence: <strong>{% if application_data.submit_and_pay_data.declaration %}Yes{% else %}No{% endif %}</strong></li>
     </ul>
 
+    {% set needs_to_post_birth_or_adoption_certificate = application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
     <h4 style="font-size: 16px;">Documents to post</h4>
     <ul class="govuk-list govuk-list--bullet" style="font-size: 16px;">
-        <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% if needs_to_post_birth_or_adoption_certificate %}
+            <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% endif %}
         {% if application_data.submit_and_pay_data.is_using_ex160_form %}
             <li>an EX160 form</li>
+        {% endif %}
+        {% if not needs_to_post_birth_or_adoption_certificate and not application_data.submit_and_pay_data.is_using_ex160_form %}
+            <li>None &ndash; all required documents have been uploaded</li>
         {% endif %}
     </ul>
 

--- a/grc/templates/applications/application_user-pdfkit.html
+++ b/grc/templates/applications/application_user-pdfkit.html
@@ -135,11 +135,17 @@
         {% endif %}
     </ul>
 
+    {% set needs_to_post_birth_or_adoption_certificate = application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
     <h4 class="govuk-heading-m">Documents to post</h4>
     <ul class="govuk-list govuk-list--bullet" style="font-size: 12px;">
-        <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% if needs_to_post_birth_or_adoption_certificate %}
+            <li>your original or a certified copy of your full birth or adoption certificate</li>
+        {% endif %}
         {% if application_data.submit_and_pay_data.is_using_ex160_form %}
             <li>an EX160 form</li>
+        {% endif %}
+        {% if not needs_to_post_birth_or_adoption_certificate and not application_data.submit_and_pay_data.is_using_ex160_form %}
+            <li>None &ndash; all required documents have been uploaded</li>
         {% endif %}
     </ul>
 

--- a/grc/templates/documents-cy.html
+++ b/grc/templates/documents-cy.html
@@ -1,11 +1,13 @@
-{% if application_data.birth_registration_data.birth_registered_in_uk %}
-    {% if application_data.birth_registration_data.adopted %}
+{% if application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
+    {% if application_data.birth_registration_data.birth_registered_in_uk %}
+        {% if application_data.birth_registration_data.adopted %}
 * eich gwreiddiol neu ardystiedig o'ch (https://www.gov.uk/certifying-a-document) tystysgrif fabwysiadu llawn
-    {% else %}
+        {% else %}
 * eich gwreiddiol neu ardystiedig o'ch (https://www.gov.uk/certifying-a-document) tystysgrif geni llawn
-    {% endif %}
-{% else %}
+        {% endif %}
+    {% else %}
 * cadarnhad swyddogol o’ch dyddiad geni a’ch rhywedd pan gawsoch eich geni
+    {% endif %}
 {% endif %}
 
 {% if application_data.submit_and_pay_data.is_using_ex160_form %}

--- a/grc/templates/documents.html
+++ b/grc/templates/documents.html
@@ -1,11 +1,13 @@
-{% if application_data.birth_registration_data.birth_registered_in_uk %}
-    {% if application_data.birth_registration_data.adopted %}
+{% if application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
+    {% if application_data.birth_registration_data.birth_registered_in_uk %}
+        {% if application_data.birth_registration_data.adopted %}
 * your original or a certified copy (https://www.gov.uk/certifying-a-document) of your full adoption certificate
-    {% else %}
+        {% else %}
 * your original or a certified copy (https://www.gov.uk/certifying-a-document) of your full birth certificate
-    {% endif %}
-{% else %}
+        {% endif %}
+    {% else %}
 * an official confirmation of date of birth and birth gender
+    {% endif %}
 {% endif %}
 
 {% if application_data.submit_and_pay_data.is_using_ex160_form %}

--- a/grc/templates/submit-and-pay/check-your-answers.html
+++ b/grc/templates/submit-and-pay/check-your-answers.html
@@ -431,7 +431,7 @@
                     value=(uploadedDocumentsList(application_data.uploads_data.statutory_declarations, 'statutoryDeclarations'))
                 ) }}
 
-                {% if application_data.need_birth_or_adoption_certificate %}
+                {% if application_data.uploads_data.birth_or_adoption_certificates | length > 0 %}
                     {{ summary_list_item.render(
                         title=_('Your birth or adoption certificate'),
                         changeLinkHiddenText='the documents you have uploaded as evidence of birth or adoption certificate',
@@ -473,24 +473,37 @@
             </dl>
 
 
-            <h2 class="govuk-heading-m">
-                 {{ _("Documents you'll need to post") }}
-            </h2>
-            <p class="govuk-body govuk-!-margin-bottom-2">
-                 {{ _('Based on your application the documents that will need to be posted are:') }}
-            </p>
+            {% set needs_to_post_birth_or_adoption_certificate = application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
+            {% set needs_to_post_documents = needs_to_post_birth_or_adoption_certificate or application_data.submit_and_pay_data.is_using_ex160_form %}
+            {% if needs_to_post_documents %}
+                <h2 class="govuk-heading-m">
+                     {{ _("Documents you'll need to post") }}
+                </h2>
+                <p class="govuk-body govuk-!-margin-bottom-2">
+                     {{ _('Based on your application the documents that will need to be posted are:') }}
+                </p>
 
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-9">
-                <li>
-                    {{ context.birth_cert_copy_link }}
-                </li>
+                <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-9">
+                    {% if needs_to_post_birth_or_adoption_certificate %}
+                        <li>
+                            {{ context.birth_cert_copy_link }}
+                        </li>
+                    {% endif %}
 
-                {% if application_data.submit_and_pay_data.is_using_ex160_form %}
-                    <li>
-                         {{ context.ex160_link }}
-                    </li>
-                {% endif %}
-            </ul>
+                    {% if application_data.submit_and_pay_data.is_using_ex160_form %}
+                        <li>
+                             {{ context.ex160_link }}
+                        </li>
+                    {% endif %}
+                </ul>
+            {% else %}
+                <h2 class="govuk-heading-m">
+                     {{ _("Documents you have provided") }}
+                </h2>
+                <p class="govuk-body govuk-!-margin-bottom-9">
+                     {{ _('You have uploaded your birth or adoption certificate. You do not need to post any documents to us unless we ask you to.') }}
+                </p>
+            {% endif %}
 
             <h2 class="govuk-heading-m">
                  {{ _('Download your application') }}

--- a/grc/templates/submit-and-pay/confirmation.html
+++ b/grc/templates/submit-and-pay/confirmation.html
@@ -4,6 +4,8 @@
 {% block title %}{{ _('Application submitted') }}{% endblock %}
 
 {% block content %}
+    {% set needs_to_post_birth_or_adoption_certificate = application_data.uploads_data.birth_or_adoption_certificates | length == 0 %}
+    {% set needs_to_post_documents = needs_to_post_birth_or_adoption_certificate or application_data.submit_and_pay_data.is_using_ex160_form %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
@@ -12,7 +14,11 @@
                     {{ _('Application submitted') }}
                 </h1>
                 <div class="govuk-panel__body">
-                    {{ _('You should post all remaining documents to us as soon as possible') }}
+                    {% if needs_to_post_documents %}
+                        {{ _('You should post all remaining documents to us as soon as possible') }}
+                    {% else %}
+                        {{ _('You do not need to post any documents to us unless we ask you to') }}
+                    {% endif %}
                 </div>
             </div>
 
@@ -20,13 +26,18 @@
                 {{ _('We have sent you a confirmation email.') }}
             </p>
 
-            <h2 class="govuk-heading-m">
-                {{ _('What you need to do next') }}
-            </h2>
-            <p class="govuk-body">
-                {{ _('Post your birth or adoption certificate to us as soon as possible – include your name, address and application reference number so we can match it to your application.') }}
-                {{ context.birth_cert_copy_link }}
-            </p>
+            {% if needs_to_post_documents %}
+                <h2 class="govuk-heading-m">
+                    {{ _('What you need to do next') }}
+                </h2>
+            {% endif %}
+
+            {% if needs_to_post_birth_or_adoption_certificate %}
+                <p class="govuk-body">
+                    {{ _('Post your birth or adoption certificate to us as soon as possible – include your name, address and application reference number so we can match it to your application.') }}
+                    {{ context.birth_cert_copy_link }}
+                </p>
+            {% endif %}
 
             {% if application_data.submit_and_pay_data.is_using_ex160_form %}
                 <p class="govuk-body">
@@ -34,23 +45,27 @@
                 </p>
             {% endif %}
 
-            <p class="govuk-body govuk-!-margin-bottom-2">
-                {{ _('If you are sending documents by Royal Mail (including tracked, special delivery, signed for, and Parcelforce), send to:') }}
-            </p>
-            <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-margin-bottom-2">
-                Gender Recognition Panel<br>
-                PO Box 11230<br>
-                Leicester<br>
-                LE1 8FQ
-            </div>
-            <p class="govuk-inset-text">
-                {{ _('If you are sending documents by courier (for example, DPD, Evri, Fedex), please contact us first (details below).') }}
-            </p>
+            {% if needs_to_post_documents %}
+                <p class="govuk-body govuk-!-margin-bottom-2">
+                    {{ _('If you are sending documents by Royal Mail (including tracked, special delivery, signed for, and Parcelforce), send to:') }}
+                </p>
+                <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+                    Gender Recognition Panel<br>
+                    PO Box 11230<br>
+                    Leicester<br>
+                    LE1 8FQ
+                </div>
+                <p class="govuk-inset-text">
+                    {{ _('If you are sending documents by courier (for example, DPD, Evri, Fedex), please contact us first (details below).') }}
+                </p>
+            {% endif %}
 
-            <p class="govuk-body">
-                {{ context.copy_birth_death_marriage_link }}
-                {{ context.scotland_norther_ireland_cert_link }}
-            </p>
+            {% if needs_to_post_birth_or_adoption_certificate %}
+                <p class="govuk-body">
+                    {{ context.copy_birth_death_marriage_link }}
+                    {{ context.scotland_norther_ireland_cert_link }}
+                </p>
+            {% endif %}
 
             <div class="govuk-warning-text">
                 <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
@@ -65,7 +80,11 @@
             </h2>
 
             <p class="govuk-body">
-                {{ _('Once you’ve sent your documents, your application will be reviewed by the Gender Recognition Panel.') }}
+                {% if needs_to_post_documents %}
+                    {{ _('Once you’ve sent your documents, your application will be reviewed by the Gender Recognition Panel.') }}
+                {% else %}
+                    {{ _('Your application will be reviewed by the Gender Recognition Panel.') }}
+                {% endif %}
                 {{ _('This usually happens within 30 weeks of you applying.') }}
             </p>
             <p class="govuk-body">

--- a/grc/templates/task-list.html
+++ b/grc/templates/task-list.html
@@ -48,7 +48,7 @@
 
             <div class="govuk-inset-text govuk-!-margin-bottom-8">
                 <p class="govuk-body">
-                    {{ _('You can upload most documents online, but you will need to post us your birth or adoption certificate') }}.
+                    {{ _('You can upload most documents online, including your birth or adoption certificate. You can also post your birth or adoption certificate to us if you cannot upload it') }}.
                 </p>
 
                 <p class="govuk-body">
@@ -156,6 +156,12 @@
                             _("Statutory declarations"),
                             url_for('upload.uploadInfoPage', section_url='statutory-declarations'),
                             application_data.section_status_statutory_declarations)
+                        }}
+
+                        {{ taskListItem(
+                            _("Your birth or adoption certificate"),
+                            url_for('upload.uploadInfoPage', section_url='birth-or-adoption-certificate'),
+                            application_data.section_status_birth_or_adoption_certificates)
                         }}
                     </ul>
                 </li>

--- a/grc/templates/upload/birth-or-adoption-certificate.html
+++ b/grc/templates/upload/birth-or-adoption-certificate.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% import "govuk-design-system-templates/error-summary.html" as error_summary %}
+{% import "upload/_upload-files-section.html" as upload_files_section %}
+{% import "govuk-design-system-templates/back_link.html" as back_link %}
+
+{% block title %}{{ _('Upload your birth or adoption certificate') }}{% endblock %}
+
+{% block backLink %}
+    {{ back_link.renderFor('taskList.index') }}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            {{ error_summary.renderFor(form) }}
+
+            <h1 class="govuk-heading-l">
+                {{ _('Upload your birth or adoption certificate') }}
+            </h1>
+            <p class="govuk-body">
+                {{ _('You can upload a scan or good quality photograph of your full birth or adoption certificate.') }}
+            </p>
+            <p class="govuk-body">
+                {{ _('If you upload your certificate, you do not need to post it to us unless we ask you to.') }}
+            </p>
+            <p class="govuk-body">
+                {{ _('If you have an adoption certificate, upload that instead of your birth certificate.') }}
+            </p>
+
+            {{ upload_files_section.renderGoodQualityStatement() }}
+
+            {{ upload_files_section.renderWarning() }}
+
+            {{ upload_files_section.renderPrivacyPolicyStatement() }}
+
+            {{ upload_files_section.render(
+                form,
+                deleteform,
+                deleteAllFilesInSectionForm,
+                currently_uploaded_files=currently_uploaded_files,
+                section_url=section_url,
+                duplicate_aws_file_names=duplicate_aws_file_names,
+                lang_code=lang_code)
+            }}
+
+        </div>
+    </div>
+{% endblock %}

--- a/grc/translations/cy/LC_MESSAGES/messages.po
+++ b/grc/translations/cy/LC_MESSAGES/messages.po
@@ -4671,7 +4671,7 @@ msgstr "Mae angen i chi ddarparu cyfeiriad e-bost i barhau â'ch cais fel y gall
 
 #: grc/templates/upload/birth-or-adoption-certificate.html
 msgid "Upload your birth or adoption certificate"
-msgstr "Uwchlwythwch eich tystysgrif geni neu fabwysiadu"
+msgstr "Uwchlwytho eich tystysgrif geni neu fabwysiadu"
 
 #: grc/templates/upload/birth-or-adoption-certificate.html
 msgid "This is where you can upload the original or certified copy of your birth or adoption certificate."
@@ -4684,3 +4684,39 @@ msgstr "Uwchlwythwch sgan neu lun o ansawdd da o’r dystysgrif."
 #: grc/templates/start-application/email-address.html
 msgid "Your email address has not been validated"
 msgstr "Nid yw eich cyfeiriad e-bost wedi’i ddilysu"
+
+#: grc/templates/task-list.html
+msgid "You can upload most documents online, including your birth or adoption certificate. You can also post your birth or adoption certificate to us if you cannot upload it"
+msgstr "Gallwch uwchlwytho'r rhan fwyaf o ddogfennau ar-lein, gan gynnwys eich tystysgrif geni neu fabwysiadu. Gallwch hefyd bostio'ch tystysgrif geni neu fabwysiadu atom os na allwch ei huwchlwytho"
+
+#: grc/templates/task-list.html grc/templates/submit-and-pay/check-your-answers.html
+msgid "Your birth or adoption certificate"
+msgstr "Eich tystysgrif geni neu fabwysiadu"
+
+#: grc/templates/upload/birth-or-adoption-certificate.html
+msgid "You can upload a scan or good quality photograph of your full birth or adoption certificate."
+msgstr "Gallwch uwchlwytho sgan neu lun o ansawdd da o'ch tystysgrif geni neu fabwysiadu lawn."
+
+#: grc/templates/upload/birth-or-adoption-certificate.html
+msgid "If you upload your certificate, you do not need to post it to us unless we ask you to."
+msgstr "Os byddwch yn uwchlwytho eich tystysgrif, nid oes angen i chi ei phostio atom oni bai ein bod yn gofyn i chi wneud hynny."
+
+#: grc/templates/upload/birth-or-adoption-certificate.html
+msgid "If you have an adoption certificate, upload that instead of your birth certificate."
+msgstr "Os oes gennych dystysgrif mabwysiadu, uwchlwythwch honno yn lle eich tystysgrif geni."
+
+#: grc/templates/submit-and-pay/check-your-answers.html
+msgid "Documents you have provided"
+msgstr "Dogfennau rydych wedi'u darparu"
+
+#: grc/templates/submit-and-pay/check-your-answers.html
+msgid "You have uploaded your birth or adoption certificate. You do not need to post any documents to us unless we ask you to."
+msgstr "Rydych wedi uwchlwytho eich tystysgrif geni neu fabwysiadu Nid oes angen i chi bostio unrhyw ddogfennau atom oni bai ein bod yn gofyn i chi wneud hynny."
+
+#: grc/templates/submit-and-pay/confirmation.html
+msgid "You do not need to post any documents to us unless we ask you to"
+msgstr "Nid oes angen i chi bostio unrhyw ddogfennau atom oni bai ein bod yn gofyn i chi wneud hynny"
+
+#: grc/templates/submit-and-pay/confirmation.html
+msgid "Your application will be reviewed by the Gender Recognition Panel."
+msgstr "Bydd eich cais yn cael ei adolygu gan y Panel Cydnabod Rhywedd."

--- a/grc/upload/__init__.py
+++ b/grc/upload/__init__.py
@@ -37,7 +37,7 @@ sections = [
     UploadSection(url='marriage-documents', data_section='marriageDocuments', html_file='marriage-documents.html', file_list=(lambda u: u.partnership_documents)),
     UploadSection(url='overseas-certificate', data_section='overseasCertificate', html_file='overseas-certificate.html', file_list=(lambda u: u.overseas_documents)),
     UploadSection(url='statutory-declarations', data_section='statutoryDeclarations', html_file='statutory-declarations.html', file_list=(lambda u: u.statutory_declarations)),
-    UploadSection(url='birth-or-adoption-certificate', data_section='birthOrAdoptionCertificate',html_file='birth-or-adoption-certificate.html', file_list=(lambda u: u.birth_or_adoption_certificates))
+    UploadSection(url='birth-or-adoption-certificate', data_section='birthOrAdoptionCertificate', html_file='birth-or-adoption-certificate.html', file_list=(lambda u: u.birth_or_adoption_certificates))
 ]
 
 

--- a/grc/upload/forms.py
+++ b/grc/upload/forms.py
@@ -39,6 +39,8 @@ class UploadForm(FlaskForm):
     )
 
     def get_csrf_token(self):
+        if not hasattr(self, '_csrf'):
+            return ''
         return self._csrf.generate_csrf_token('csrf_token')
 
 
@@ -48,6 +50,8 @@ class DeleteForm(FlaskForm):
     )
 
     def get_csrf_token(self):
+        if not hasattr(self, '_csrf'):
+            return ''
         return self._csrf.generate_csrf_token('csrf_token')
 
 
@@ -77,9 +81,13 @@ class PasswordsForm(FlaskForm):
     files = FieldList(FormField(PasswordForm), min_entries=1)
 
     def get_csrf_token(self):
+        if not hasattr(self, '_csrf'):
+            return ''
         return self._csrf.generate_csrf_token('csrf_token')
 
 
 class DeleteAllFilesInSectionForm(FlaskForm):
     def get_csrf_token(self):
+        if not hasattr(self, '_csrf'):
+            return ''
         return self._csrf.generate_csrf_token('csrf_token')

--- a/tests/admin/applications/test_view_application.py
+++ b/tests/admin/applications/test_view_application.py
@@ -1,0 +1,146 @@
+from datetime import date, datetime
+
+import pytest
+from flask import render_template_string
+
+from grc.business_logic.data_store import DataStore
+from grc.business_logic.data_structures.application_data import ApplicationData
+from grc.business_logic.data_structures.personal_details_data import AffirmedGender, ContactDatesAvoid
+from grc.business_logic.data_structures.partnership_details_data import CurrentlyInAPartnershipEnum
+from grc.business_logic.data_structures.uploads_data import EvidenceFile
+from grc.models import db
+
+
+def birth_or_adoption_certificate_file():
+    evidence_file = EvidenceFile()
+    evidence_file.original_file_name = 'birth-certificate.pdf'
+    evidence_file.aws_file_name = 'ABCD1234__birthOrAdoptionCertificate__birth-certificate.pdf'
+    return evidence_file
+
+
+def populate_application_data_for_view(application_data):
+    application_data.confirmation_data.gender_recognition_outside_uk = False
+    application_data.confirmation_data.consent_to_GRO_contact = True
+
+    personal_details = application_data.personal_details_data
+    personal_details.title = 'Mx'
+    personal_details.first_name = 'Alex'
+    personal_details.last_name = 'Example'
+    personal_details.affirmed_gender = AffirmedGender.MALE
+    personal_details.transition_date = date(2020, 1, 1)
+    personal_details.statutory_declaration_date = date(2024, 1, 1)
+    personal_details.changed_name_to_reflect_gender = False
+    personal_details.address_line_one = '1 Test Street'
+    personal_details.address_town_city = 'Test Town'
+    personal_details.address_country = 'United Kingdom'
+    personal_details.address_postcode = 'TE1 1ST'
+    personal_details.contact_email_address = 'alex@example.com'
+    personal_details.contact_by_post = False
+    personal_details.contact_dates_should_avoid = False
+    personal_details.contact_dates_to_avoid_option = ContactDatesAvoid.NO_DATES
+    personal_details.tell_hmrc = False
+
+    birth_registration = application_data.birth_registration_data
+    birth_registration.first_name = 'Alex'
+    birth_registration.last_name = 'Example'
+    birth_registration.date_of_birth = date(1990, 1, 1)
+    birth_registration.birth_registered_in_uk = True
+    birth_registration.town_city_of_birth = 'Test City'
+    birth_registration.mothers_first_name = 'Pat'
+    birth_registration.mothers_last_name = 'Example'
+    birth_registration.mothers_maiden_name = 'Original'
+    birth_registration.fathers_name_on_birth_certificate = False
+    birth_registration.adopted = False
+    birth_registration.forces_registration = False
+
+    partnership_details = application_data.partnership_details_data
+    partnership_details.currently_in_a_partnership = CurrentlyInAPartnershipEnum.NEITHER
+    partnership_details.previous_partnership_partner_died = False
+    partnership_details.previous_partnership_ended = False
+
+    application_data.submit_and_pay_data.applying_for_help_with_fee = False
+
+
+class TestAdminViewApplicationBirthOrAdoptionCertificate:
+
+    @pytest.fixture(autouse=True)
+    def _create_schema(self, app):
+        with app.app_context():
+            db.create_all()
+            yield
+            db.session.remove()
+            db.drop_all()
+
+    def test_shows_uploaded_certificate_and_no_documents_to_post(self, app, client, submitted_application_unregistered):
+        with app.app_context():
+            with client.session_transaction() as session:
+                session['signedIn'] = 'test.email@example.com'
+
+            application_data = DataStore.load_application('ABCD1234')
+            populate_application_data_for_view(application_data)
+            application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+            DataStore.save_application(application_data)
+
+            response = client.get('/applications/ABCD1234')
+            html = response.data.decode()
+
+            assert response.status_code == 200
+            assert 'Your birth or adoption certificate' in html
+            assert 'birth-certificate.pdf' in html
+
+            documents_to_post_section = html.split('Documents to post')[1]
+            assert 'Yes' not in documents_to_post_section.split('An EX160 form')[0]
+            assert 'No' in documents_to_post_section
+
+    def test_keeps_documents_to_post_when_certificate_not_uploaded(self, app, client, submitted_application_unregistered):
+        with app.app_context():
+            with client.session_transaction() as session:
+                session['signedIn'] = 'test.email@example.com'
+
+            application_data = DataStore.load_application('ABCD1234')
+            populate_application_data_for_view(application_data)
+            DataStore.save_application(application_data)
+
+            response = client.get('/applications/ABCD1234')
+            html = response.data.decode()
+
+            assert response.status_code == 200
+            documents_to_post_section = html.split('Documents to post')[1]
+            assert 'Yes' in documents_to_post_section.split('An EX160 form')[0]
+
+
+class TestAdminGeneratedPdfBirthOrAdoptionCertificate:
+
+    def test_admin_pdf_omits_certificate_from_documents_to_post_when_uploaded(self, app):
+        with app.app_context():
+            with app.test_request_context():
+                application_data = ApplicationData()
+                populate_application_data_for_view(application_data)
+                application_data.updated = datetime(2024, 1, 1, 9)
+                application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+
+                response = render_template_string(
+                    "{% from 'applications/application-pdfkit.html' import adminapplication %}"
+                    "{{ adminapplication(application_data) }}",
+                    application_data=application_data
+                )
+
+                documents_to_post_section = response.split('Documents to post')[1]
+                assert 'your original or a certified copy of your full birth or adoption certificate' not in documents_to_post_section
+                assert 'None' in documents_to_post_section
+
+    def test_admin_pdf_keeps_certificate_in_documents_to_post_when_not_uploaded(self, app):
+        with app.app_context():
+            with app.test_request_context():
+                application_data = ApplicationData()
+                populate_application_data_for_view(application_data)
+                application_data.updated = datetime(2024, 1, 1, 9)
+
+                response = render_template_string(
+                    "{% from 'applications/application-pdfkit.html' import adminapplication %}"
+                    "{{ adminapplication(application_data) }}",
+                    application_data=application_data
+                )
+
+                documents_to_post_section = response.split('Documents to post')[1]
+                assert 'your original or a certified copy of your full birth or adoption certificate' in documents_to_post_section

--- a/tests/end_to_end_tests/journey_1/birth_registration/section.py
+++ b/tests/end_to_end_tests/journey_1/birth_registration/section.py
@@ -784,7 +784,7 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.number_of_errors(0)
 
     # Status of "Your birth registration information" section should be "COMPLETED"
-    await asserts.task_list_sections(8)
+    await asserts.task_list_sections(9)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -792,4 +792,5 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.task_list_section(section='Name change documents', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')

--- a/tests/end_to_end_tests/journey_1/login_and_confirmation/section.py
+++ b/tests/end_to_end_tests/journey_1/login_and_confirmation/section.py
@@ -325,11 +325,12 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.number_of_errors(0)
 
     # Status of "Confirmation" section should be "COMPLETED"
-    await asserts.task_list_sections(7)
+    await asserts.task_list_sections(8)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Not started')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Not started')
     await asserts.task_list_section(section='Marriage or civil partnership details', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')

--- a/tests/end_to_end_tests/journey_1/partnership_details/section.py
+++ b/tests/end_to_end_tests/journey_1/partnership_details/section.py
@@ -1139,7 +1139,7 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
 
     # Status of "Marriage or civil partnership details" section should be "COMPLETED"
     # The "Marriage documents" section should now be visible
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -1148,4 +1148,5 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')

--- a/tests/end_to_end_tests/journey_1/personal_details/section.py
+++ b/tests/end_to_end_tests/journey_1/personal_details/section.py
@@ -109,13 +109,14 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.number_of_errors(0)
 
     # Status of "Your personal details" section should be "IN PROGRESS"
-    await asserts.task_list_sections(7)
+    await asserts.task_list_sections(8)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='In progress')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Not started')
     await asserts.task_list_section(section='Marriage or civil partnership details', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Your personal details"
@@ -916,7 +917,7 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.number_of_errors(0)
 
     # Status of "Your personal details" section should be "COMPLETED"
-    await asserts.task_list_sections(8)
+    await asserts.task_list_sections(9)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Not started')
@@ -924,6 +925,7 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.task_list_section(section='Name change documents', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # TODO:

--- a/tests/end_to_end_tests/journey_1/uploads/page_birth_or_adoption_certificate.py
+++ b/tests/end_to_end_tests/journey_1/uploads/page_birth_or_adoption_certificate.py
@@ -1,0 +1,161 @@
+from playwright.async_api import Page
+from tests.end_to_end_tests.helpers.e2e_assert_helpers import AssertHelpers
+from tests.end_to_end_tests.helpers.e2e_page_helpers import PageHelpers
+import tests.end_to_end_tests.journey_1.data as data
+
+
+TASK_LIST_BUTTON_NAME = 'Your birth or adoption certificate'
+PAGE_URL = '/upload/birth-or-adoption-certificate'
+PAGE_H1 = 'Upload your birth or adoption certificate'
+
+
+async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHelpers):
+
+    # ------------------------------------------------
+    # ---- Task List page
+    # ------------------------------------------------
+    await asserts.url('/task-list')
+    await asserts.accessibility()
+    await asserts.h1('Your application')
+    await asserts.number_of_errors(0)
+
+    # Click "Your birth or adoption certificate" to go to the upload page
+    await helpers.click_button(TASK_LIST_BUTTON_NAME)
+
+    # ------------------------------------------------
+    # ---- Birth or Adoption Certificate page
+    # ------------------------------------------------
+    await asserts.url(PAGE_URL)
+    await asserts.accessibility()
+    await asserts.h1(PAGE_H1)
+    await asserts.number_of_errors(0)
+
+    # "Back" should take us to the Task List page
+    await helpers.click_button('Back')
+
+    # ------------------------------------------------
+    # ---- Task List page
+    # ------------------------------------------------
+    await asserts.url('/task-list')
+    await asserts.accessibility()
+    await asserts.h1('Your application')
+    await asserts.number_of_errors(0)
+
+    # Continue to the "Birth or Adoption Certificate" page again
+    await helpers.click_button(TASK_LIST_BUTTON_NAME)
+
+    # ------------------------------------------------
+    # ---- Birth or Adoption Certificate page
+    # ------------------------------------------------
+    await asserts.url(PAGE_URL)
+    await asserts.accessibility()
+    await asserts.h1(PAGE_H1)
+    await asserts.number_of_errors(0)
+    await asserts.documents_uploaded(0)
+
+    # Try to upload a document of the wrong type
+    await helpers.upload_file_invalid_file_type(field='documents')
+    await helpers.click_button('Upload 1 file')
+    await asserts.url(PAGE_URL)
+    await asserts.accessibility()
+    await asserts.h1(PAGE_H1)
+    await asserts.number_of_errors(1)
+    await asserts.error(field='documents', message='Select a JPG, BMP, PNG, TIF or PDF file smaller than 10MB')
+    await asserts.documents_uploaded(0)
+
+    DOCUMENT_ONE_NAME = 'document_1.bmp'
+
+    # Upload a valid document
+    await helpers.upload_file_valid(field='documents', file_name=DOCUMENT_ONE_NAME)
+    page.set_default_timeout(data.TIMEOUT_FOR_SLOW_OPERATIONS)
+    await helpers.click_button('Upload 1 file')
+    await asserts.url(PAGE_URL)
+    page.set_default_timeout(data.DEFAULT_TIMEOUT)
+    await asserts.accessibility()
+    await asserts.h1(PAGE_H1)
+    await asserts.number_of_errors(0)
+    await asserts.documents_uploaded(1)
+    await asserts.document_uploaded(file_name=DOCUMENT_ONE_NAME)
+
+    # Remove the uploaded document
+    await helpers.click_button(f"Remove file {DOCUMENT_ONE_NAME}")
+    await asserts.url(PAGE_URL)
+    await asserts.accessibility()
+    await asserts.h1(PAGE_H1)
+    await asserts.number_of_errors(0)
+    await asserts.documents_uploaded(0)
+
+    # Return to Task List page without uploading a file
+    # Because this section is optional, this should be allowed even with no upload
+    await helpers.click_button('Return to task list')
+
+    # ------------------------------------------------
+    # ---- Task List page
+    # ------------------------------------------------
+    await asserts.url('/task-list')
+    await asserts.accessibility()
+    await asserts.h1('Your application')
+    await asserts.number_of_errors(0)
+
+    # Status of "Your birth or adoption certificate" section should be "NOT STARTED"
+    await asserts.task_list_sections(10)
+    await asserts.task_list_section(section='Confirmation', expected_status='Completed')
+    await asserts.task_list_section(section='Your personal details', expected_status='Completed')
+    await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
+    await asserts.task_list_section(section='Marriage or civil partnership details', expected_status='Completed')
+    await asserts.task_list_section(section='Name change documents', expected_status='Completed')
+    await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Completed')
+    await asserts.task_list_section(section='Overseas certificate documents', expected_status='Completed')
+    await asserts.task_list_section(section='Statutory declarations', expected_status='Completed')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
+    await asserts.task_list_section(section='Submit and pay', expected_status='Not started')
+
+    # Click "Your birth or adoption certificate" to go back to the upload page
+    await helpers.click_button(TASK_LIST_BUTTON_NAME)
+
+    # ------------------------------------------------
+    # ---- Birth or Adoption Certificate page
+    # ------------------------------------------------
+    await asserts.url(PAGE_URL)
+    await asserts.accessibility()
+    await asserts.h1(PAGE_H1)
+    await asserts.number_of_errors(0)
+    await asserts.documents_uploaded(0)
+
+    # Upload a valid document
+    await helpers.upload_file_valid(field='documents', file_name=DOCUMENT_ONE_NAME)
+    page.set_default_timeout(data.TIMEOUT_FOR_SLOW_OPERATIONS)
+    await helpers.click_button('Upload 1 file')
+    await asserts.url(PAGE_URL)
+    page.set_default_timeout(data.DEFAULT_TIMEOUT)
+    await asserts.accessibility()
+    await asserts.h1(PAGE_H1)
+    await asserts.number_of_errors(0)
+    await asserts.documents_uploaded(1)
+    await asserts.document_uploaded(file_name=DOCUMENT_ONE_NAME)
+
+    # Click "Save and continue"
+    # Now that there is a file uploaded, we should be taken to the Task List page
+    # "Your birth or adoption certificate" section should be marked as "COMPLETED"
+    await helpers.click_button('Save and continue')
+
+    # ------------------------------------------------
+    # ---- Task List page
+    # ------------------------------------------------
+    await asserts.url('/task-list')
+    await asserts.accessibility()
+    await asserts.h1('Your application')
+    await asserts.number_of_errors(0)
+
+    # Status of "Your birth or adoption certificate" section should be "COMPLETED"
+    await asserts.task_list_sections(10)
+    await asserts.task_list_section(section='Confirmation', expected_status='Completed')
+    await asserts.task_list_section(section='Your personal details', expected_status='Completed')
+    await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
+    await asserts.task_list_section(section='Marriage or civil partnership details', expected_status='Completed')
+    await asserts.task_list_section(section='Name change documents', expected_status='Completed')
+    await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Completed')
+    await asserts.task_list_section(section='Overseas certificate documents', expected_status='Completed')
+    await asserts.task_list_section(section='Statutory declarations', expected_status='Completed')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Completed')
+    await asserts.task_list_section(section='Submit and pay', expected_status='Not started')

--- a/tests/end_to_end_tests/journey_1/uploads/page_marriage_documents.py
+++ b/tests/end_to_end_tests/journey_1/uploads/page_marriage_documents.py
@@ -131,7 +131,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Marriage documents" section should be "NOT STARTED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -140,6 +140,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Marriage documents" to go back to the "Marriage Documents" page
@@ -180,7 +181,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Marriage documents" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -189,6 +190,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Completed')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Marriage documents" to go back to the "Marriage Documents" page

--- a/tests/end_to_end_tests/journey_1/uploads/page_name_change_documents.py
+++ b/tests/end_to_end_tests/journey_1/uploads/page_name_change_documents.py
@@ -131,7 +131,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Name change documents" section should be "NOT STARTED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -140,6 +140,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Name change documents" to go back to the "Name Change Documents" page
@@ -180,7 +181,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Name change documents" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -189,6 +190,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Not started')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Name change documents" to go back to the "Name Change Documents" page

--- a/tests/end_to_end_tests/journey_1/uploads/page_overseas_documents.py
+++ b/tests/end_to_end_tests/journey_1/uploads/page_overseas_documents.py
@@ -131,7 +131,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Overseas certificate documents" section should be "NOT STARTED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -140,6 +140,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Completed')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Not started')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Overseas certificate documents" to go back to the "Overseas certificate Documents" page
@@ -180,7 +181,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Overseas certificate documents" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -189,6 +190,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Completed')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Completed')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Overseas certificate documents" to go back to the "Overseas certificate Documents" page

--- a/tests/end_to_end_tests/journey_1/uploads/page_statutory_declarations.py
+++ b/tests/end_to_end_tests/journey_1/uploads/page_statutory_declarations.py
@@ -131,7 +131,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Statutory declarations" section should be "NOT STARTED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -140,6 +140,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Completed')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Completed')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Not started')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Cannot start yet')
 
     # Click "Statutory declarations" to go back to the "Statutory Declarations" page
@@ -180,7 +181,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Statutory declarations" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Confirmation', expected_status='Completed')
     await asserts.task_list_section(section='Your personal details', expected_status='Completed')
     await asserts.task_list_section(section='Your birth registration information', expected_status='Completed')
@@ -189,6 +190,7 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.task_list_section(section='Marriage and civil partnership documents', expected_status='Completed')
     await asserts.task_list_section(section='Overseas certificate documents', expected_status='Completed')
     await asserts.task_list_section(section='Statutory declarations', expected_status='Completed')
+    await asserts.task_list_section(section='Your birth or adoption certificate', expected_status='Not started')
     await asserts.task_list_section(section='Submit and pay', expected_status='Not started')
 
     # Click "Statutory declarations" to go back to the "Statutory Declarations" page

--- a/tests/end_to_end_tests/journey_1/uploads/section.py
+++ b/tests/end_to_end_tests/journey_1/uploads/section.py
@@ -5,6 +5,7 @@ import tests.end_to_end_tests.journey_1.uploads.page_name_change_documents as pa
 import tests.end_to_end_tests.journey_1.uploads.page_marriage_documents as page_marriage_documents
 import tests.end_to_end_tests.journey_1.uploads.page_overseas_documents as page_overseas_documents
 import tests.end_to_end_tests.journey_1.uploads.page_statutory_declarations as page_statutory_declarations
+import tests.end_to_end_tests.journey_1.uploads.page_birth_or_adoption_certificate as page_birth_or_adoption_certificate
 
 
 async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: PageHelpers):
@@ -28,3 +29,8 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     # ---- Statutory Declarations page
     # ------------------------------------------------
     await page_statutory_declarations.run_checks_on_page(page, asserts, helpers)
+
+    # ------------------------------------------------
+    # ---- Birth or Adoption Certificate page
+    # ------------------------------------------------
+    await page_birth_or_adoption_certificate.run_checks_on_page(page, asserts, helpers)

--- a/tests/end_to_end_tests/journey_cy/login_and_confirmation/section.py
+++ b/tests/end_to_end_tests/journey_cy/login_and_confirmation/section.py
@@ -147,7 +147,7 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await asserts.h1('Eich cais')
 
     # Status of "Confirmation" section should be "COMPLETED"
-    await asserts.task_list_sections(7)
+    await asserts.task_list_sections(8)
     await asserts.task_list_section(section='Cadarnhau', expected_status="Wedi'i gwblhau")
     await asserts.task_list_section(section='Eich manylion personol', expected_status='Heb ddechrau')
     await asserts.task_list_section(section='Gwybodaeth am gofrestru eich genedigaeth', expected_status='Heb ddechrau')

--- a/tests/end_to_end_tests/journey_cy/uploads/page_marriage_documents.py
+++ b/tests/end_to_end_tests/journey_cy/uploads/page_marriage_documents.py
@@ -85,5 +85,5 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Marriage Documents page" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Dogfennau priodas a phartneriaeth sifil', expected_status="Wedi'i gwblhau")

--- a/tests/end_to_end_tests/journey_cy/uploads/page_name_change_documents.py
+++ b/tests/end_to_end_tests/journey_cy/uploads/page_name_change_documents.py
@@ -84,5 +84,5 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Name Change Documents page" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Dogfennau newid enw', expected_status="Wedi'i gwblhau")

--- a/tests/end_to_end_tests/journey_cy/uploads/page_overseas_documents.py
+++ b/tests/end_to_end_tests/journey_cy/uploads/page_overseas_documents.py
@@ -84,5 +84,5 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Overseas certificate documents" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Dogfennau Tystysgrif o Dramor', expected_status="Wedi'i gwblhau")

--- a/tests/end_to_end_tests/journey_cy/uploads/page_statutory_declarations.py
+++ b/tests/end_to_end_tests/journey_cy/uploads/page_statutory_declarations.py
@@ -85,5 +85,5 @@ async def run_checks_on_page(page: Page, asserts: AssertHelpers, helpers: PageHe
     await asserts.number_of_errors(0)
 
     # Status of "Statutory declarations" section should be "COMPLETED"
-    await asserts.task_list_sections(9)
+    await asserts.task_list_sections(10)
     await asserts.task_list_section(section='Datganiadau statudol', expected_status="Wedi'i gwblhau")

--- a/tests/grc/integration/test_birth_or_adoption_certificate_upload.py
+++ b/tests/grc/integration/test_birth_or_adoption_certificate_upload.py
@@ -1,0 +1,126 @@
+import pytest
+import io
+from flask.sessions import SecureCookieSessionInterface
+
+import grc.upload as upload_module
+from grc.business_logic.data_structures.application_data import ApplicationData
+from grc.models import Application, db
+from tests.grc.integration.conftest import load_test_data, save_test_data
+
+
+@pytest.fixture()
+def client(app):
+    app.secret_key = 'test-secret-key'
+    app.config['AV_API'] = None
+    app.session_interface = SecureCookieSessionInterface()
+    return app.test_client()
+
+
+@pytest.fixture()
+def test_application(app, public_user_email):
+    with app.app_context():
+        db.create_all()
+
+        application_record = Application(
+            reference_number='ABCD1234',
+            email=public_user_email
+        )
+
+        db.session.add(application_record)
+        db.session.commit()
+
+        data = ApplicationData()
+        data.reference_number = application_record.reference_number
+        data.email_address = application_record.email
+        save_test_data(data)
+
+        yield application_record
+
+        db.session.remove()
+        db.drop_all()
+
+
+def test_birth_or_adoption_certificate_upload_page(app, client, test_application):
+    with app.app_context():
+        with client.session_transaction() as session:
+            session['reference_number'] = test_application.reference_number
+            session['identity_verified'] = True
+
+        response = client.get('/upload/birth-or-adoption-certificate')
+
+        assert response.status_code == 200
+        assert 'Upload your birth or adoption certificate' in response.text
+        assert 'The files must be a JPG, BMP, PNG, TIF or PDF and smaller than 10MB' in response.text
+
+
+def test_birth_or_adoption_certificate_upload_page_requires_login(app, client):
+    with app.app_context():
+        response = client.get('/upload/birth-or-adoption-certificate')
+
+        assert response.status_code == 302
+        assert response.location == '/'
+
+
+def test_birth_or_adoption_certificate_supported_file_saves(app, client, test_application, monkeypatch):
+    class FakeAwsS3Client:
+        def upload_fileobj(self, file_object, object_name):
+            pass
+
+    monkeypatch.setattr(upload_module, 'AwsS3Client', lambda: FakeAwsS3Client())
+
+    with app.app_context():
+        with client.session_transaction() as session:
+            session['reference_number'] = test_application.reference_number
+            session['identity_verified'] = True
+
+        response = client.post(
+            '/upload/birth-or-adoption-certificate',
+            data={
+                'button_clicked': 'UPLOAD_FILE',
+                'documents': (io.BytesIO(b'%PDF-1.4 test file'), 'birth-certificate.pdf')
+            },
+            content_type='multipart/form-data'
+        )
+
+        application_data = load_test_data(test_application.reference_number)
+
+        assert response.status_code == 302
+        assert response.location == '/upload/birth-or-adoption-certificate#file-upload-section'
+        assert len(application_data.uploads_data.birth_or_adoption_certificates) == 1
+        assert application_data.uploads_data.birth_or_adoption_certificates[0].original_file_name == 'birth-certificate.pdf'
+
+
+def test_birth_or_adoption_certificate_unsupported_file_is_rejected(app, client, test_application):
+    with app.app_context():
+        with client.session_transaction() as session:
+            session['reference_number'] = test_application.reference_number
+            session['identity_verified'] = True
+
+        response = client.post(
+            '/upload/birth-or-adoption-certificate',
+            data={
+                'button_clicked': 'UPLOAD_FILE',
+                'documents': (io.BytesIO(b'not a supported file'), 'birth-certificate.txt')
+            },
+            content_type='multipart/form-data'
+        )
+
+        application_data = load_test_data(test_application.reference_number)
+
+        assert response.status_code == 200
+        assert 'Select a JPG, BMP, PNG, TIF or PDF file smaller than 10MB' in response.text
+        assert application_data.uploads_data.birth_or_adoption_certificates == []
+
+
+def test_task_list_shows_birth_or_adoption_certificate_upload(app, client, test_application):
+    with app.app_context():
+        with client.session_transaction() as session:
+            session['reference_number'] = test_application.reference_number
+            session['identity_verified'] = True
+
+        response = client.get('/task-list')
+
+        assert response.status_code == 200
+        assert 'Your birth or adoption certificate' in response.text
+        assert '/upload/birth-or-adoption-certificate' in response.text
+        assert 'You can also post your birth or adoption certificate to us if you cannot upload it' in response.text

--- a/tests/grc/unit/test_birth_or_adoption_certificate_upload.py
+++ b/tests/grc/unit/test_birth_or_adoption_certificate_upload.py
@@ -1,0 +1,262 @@
+from types import SimpleNamespace
+from datetime import date, datetime
+
+from flask import g, render_template, render_template_string
+
+from grc.business_logic.data_structures.application_data import ApplicationData
+from grc.business_logic.data_structures.personal_details_data import AffirmedGender, ContactDatesAvoid
+from grc.business_logic.data_structures.partnership_details_data import CurrentlyInAPartnershipEnum
+from grc.business_logic.data_structures.submit_and_pay_data import HelpWithFeesType
+from grc.business_logic.data_structures.uploads_data import EvidenceFile
+from grc.list_status import ListStatus
+from grc.submit_and_pay.forms import CheckYourAnswers
+
+
+def birth_or_adoption_certificate_file():
+    evidence_file = EvidenceFile()
+    evidence_file.original_file_name = 'birth-certificate.pdf'
+    evidence_file.aws_file_name = 'ABCD1234__birthOrAdoptionCertificate__birth-certificate.pdf'
+    return evidence_file
+
+
+def populate_check_your_answers_data(application_data):
+    application_data.confirmation_data.gender_recognition_outside_uk = False
+    application_data.confirmation_data.consent_to_GRO_contact = True
+
+    personal_details = application_data.personal_details_data
+    personal_details.title = 'Mx'
+    personal_details.first_name = 'Alex'
+    personal_details.last_name = 'Example'
+    personal_details.affirmed_gender = AffirmedGender.MALE
+    personal_details.transition_date = date(2020, 1, 1)
+    personal_details.statutory_declaration_date = date(2024, 1, 1)
+    personal_details.changed_name_to_reflect_gender = False
+    personal_details.address_line_one = '1 Test Street'
+    personal_details.address_town_city = 'Test Town'
+    personal_details.address_country = 'United Kingdom'
+    personal_details.address_postcode = 'TE1 1ST'
+    personal_details.contact_email_address = 'alex@example.com'
+    personal_details.contact_by_post = False
+    personal_details.contact_dates_should_avoid = False
+    personal_details.contact_dates_to_avoid_option = ContactDatesAvoid.NO_DATES
+    personal_details.tell_hmrc = False
+
+    birth_registration = application_data.birth_registration_data
+    birth_registration.first_name = 'Alex'
+    birth_registration.last_name = 'Example'
+    birth_registration.date_of_birth = date(1990, 1, 1)
+    birth_registration.birth_registered_in_uk = True
+    birth_registration.town_city_of_birth = 'Test City'
+    birth_registration.mothers_first_name = 'Pat'
+    birth_registration.mothers_last_name = 'Example'
+    birth_registration.mothers_maiden_name = 'Original'
+    birth_registration.fathers_name_on_birth_certificate = False
+    birth_registration.adopted = False
+    birth_registration.forces_registration = False
+
+    partnership_details = application_data.partnership_details_data
+    partnership_details.currently_in_a_partnership = CurrentlyInAPartnershipEnum.NEITHER
+    partnership_details.previous_partnership_partner_died = False
+    partnership_details.previous_partnership_ended = False
+
+
+def test_birth_or_adoption_certificate_section_is_optional_and_visible(app):
+    with app.app_context():
+        application_data = ApplicationData()
+
+        assert application_data.need_birth_or_adoption_certificate is True
+        assert application_data.section_status_birth_or_adoption_certificates == ListStatus.NOT_STARTED
+
+
+def test_birth_or_adoption_certificate_section_is_completed_when_file_uploaded(app):
+    with app.app_context():
+        application_data = ApplicationData()
+        application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+
+        assert application_data.section_status_birth_or_adoption_certificates == ListStatus.COMPLETED
+
+
+def test_confirmation_does_not_ask_for_posted_certificate_when_uploaded(app):
+    with app.test_request_context():
+        g.build_info = SimpleNamespace(git_commit='test')
+        g.lang_code = 'en'
+        application_data = ApplicationData()
+        application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+        context = {
+            'birth_cert_copy_link': 'BIRTH_CERT_LINK',
+            'ex160_link': 'EX160_LINK',
+            'copy_birth_death_marriage_link': 'COPY_CERT_LINK',
+            'scotland_norther_ireland_cert_link': 'SCOTLAND_NI_LINK'
+        }
+
+        response = render_template(
+            'submit-and-pay/confirmation.html',
+            application_data=application_data,
+            context=context
+        )
+
+        assert 'You do not need to post any documents to us unless we ask you to' in response
+        assert 'Post your birth or adoption certificate to us as soon as possible' not in response
+        assert 'BIRTH_CERT_LINK' not in response
+
+
+def test_confirmation_keeps_postal_guidance_when_no_certificate_uploaded(app):
+    with app.test_request_context():
+        g.build_info = SimpleNamespace(git_commit='test')
+        g.lang_code = 'en'
+        application_data = ApplicationData()
+        context = {
+            'birth_cert_copy_link': 'BIRTH_CERT_LINK',
+            'ex160_link': 'EX160_LINK',
+            'copy_birth_death_marriage_link': 'COPY_CERT_LINK',
+            'scotland_norther_ireland_cert_link': 'SCOTLAND_NI_LINK'
+        }
+
+        response = render_template(
+            'submit-and-pay/confirmation.html',
+            application_data=application_data,
+            context=context
+        )
+
+        assert 'Post your birth or adoption certificate to us as soon as possible' in response
+        assert 'BIRTH_CERT_LINK' in response
+
+
+def test_documents_email_omits_certificate_when_uploaded(app):
+    with app.test_request_context():
+        application_data = ApplicationData()
+        application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+
+        response = render_template('documents.html', application_data=application_data)
+
+        assert 'birth certificate' not in response
+        assert 'adoption certificate' not in response
+
+
+def test_documents_email_keeps_ex160_when_certificate_uploaded(app):
+    with app.test_request_context():
+        application_data = ApplicationData()
+        application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+        application_data.submit_and_pay_data.how_applying_for_help_with_fees = HelpWithFeesType.USING_EX160_FORM
+
+        response = render_template('documents.html', application_data=application_data)
+
+        assert 'EX160 form' in response
+
+
+def test_check_your_answers_shows_uploaded_certificate_and_omits_postal_certificate(app):
+    with app.test_request_context():
+        g.build_info = SimpleNamespace(git_commit='test')
+        g.lang_code = 'en'
+        application_data = ApplicationData()
+        populate_check_your_answers_data(application_data)
+        application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+        application_data.submit_and_pay_data.applying_for_help_with_fee = False
+        context = {
+            'birth_cert_copy_link': 'BIRTH_CERT_LINK',
+            'ex160_link': 'EX160_LINK'
+        }
+
+        response = render_template(
+            'submit-and-pay/check-your-answers.html',
+            form=CheckYourAnswers(),
+            application_data=application_data,
+            context=context,
+            back='taskList.index'
+        )
+
+        assert 'Your birth or adoption certificate' in response
+        assert 'birth-certificate.pdf' in response
+        assert 'BIRTH_CERT_LINK' not in response
+
+
+def test_check_your_answers_keeps_postal_certificate_when_not_uploaded(app):
+    with app.test_request_context():
+        g.build_info = SimpleNamespace(git_commit='test')
+        g.lang_code = 'en'
+        application_data = ApplicationData()
+        populate_check_your_answers_data(application_data)
+        application_data.submit_and_pay_data.applying_for_help_with_fee = False
+        context = {
+            'birth_cert_copy_link': 'BIRTH_CERT_LINK',
+            'ex160_link': 'EX160_LINK'
+        }
+
+        response = render_template(
+            'submit-and-pay/check-your-answers.html',
+            form=CheckYourAnswers(),
+            application_data=application_data,
+            context=context,
+            back='taskList.index'
+        )
+
+        assert 'Your birth or adoption certificate' not in response
+        assert 'BIRTH_CERT_LINK' in response
+
+
+def test_admin_pdf_omits_certificate_from_documents_to_post_when_uploaded(app):
+    with app.test_request_context():
+        application_data = ApplicationData()
+        populate_check_your_answers_data(application_data)
+        application_data.updated = datetime(2024, 1, 1, 9)
+        application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+
+        response = render_template_string(
+            "{% from 'applications/application.html' import adminapplication %}"
+            "{{ adminapplication(application_data) }}",
+            application_data=application_data
+        )
+
+        documents_to_post_section = response.split('Documents to post')[1]
+        assert 'your original or a certified copy of your full birth or adoption certificate' not in documents_to_post_section
+        assert 'None' in documents_to_post_section
+
+
+def test_admin_pdf_keeps_certificate_in_documents_to_post_when_not_uploaded(app):
+    with app.test_request_context():
+        application_data = ApplicationData()
+        populate_check_your_answers_data(application_data)
+        application_data.updated = datetime(2024, 1, 1, 9)
+
+        response = render_template_string(
+            "{% from 'applications/application.html' import adminapplication %}"
+            "{{ adminapplication(application_data) }}",
+            application_data=application_data
+        )
+
+        documents_to_post_section = response.split('Documents to post')[1]
+        assert 'your original or a certified copy of your full birth or adoption certificate' in documents_to_post_section
+
+
+def test_applicant_pdf_omits_certificate_from_documents_to_post_when_uploaded(app):
+    with app.test_request_context():
+        application_data = ApplicationData()
+        populate_check_your_answers_data(application_data)
+        application_data.updated = datetime(2024, 1, 1, 9)
+        application_data.uploads_data.birth_or_adoption_certificates = [birth_or_adoption_certificate_file()]
+
+        response = render_template_string(
+            "{% from 'applications/application_user-pdfkit.html' import userapplication %}"
+            "{{ userapplication(application_data) }}",
+            application_data=application_data
+        )
+
+        documents_to_post_section = response.split('Documents to post')[1]
+        assert 'your original or a certified copy of your full birth or adoption certificate' not in documents_to_post_section
+        assert 'None' in documents_to_post_section
+
+
+def test_applicant_pdf_keeps_certificate_in_documents_to_post_when_not_uploaded(app):
+    with app.test_request_context():
+        application_data = ApplicationData()
+        populate_check_your_answers_data(application_data)
+        application_data.updated = datetime(2024, 1, 1, 9)
+
+        response = render_template_string(
+            "{% from 'applications/application_user-pdfkit.html' import userapplication %}"
+            "{{ userapplication(application_data) }}",
+            application_data=application_data
+        )
+
+        documents_to_post_section = response.split('Documents to post')[1]
+        assert 'your original or a certified copy of your full birth or adoption certificate' in documents_to_post_section


### PR DESCRIPTION
## TPET-831 — Digital birth certificate upload

Jira: https://tools.hmcts.net/jira/browse/TPET-831

### What & why
Applicants were always instructed to post their birth or adoption certificate.
TPET-831 adds a digital upload option so the certificate is attached to the
application and can be reviewed by the team. Applicants who upload a certificate
are not asked to post it unless the Gender Recognition Panel asks; posting remains
the fallback for applicants who do not upload.

### Changes
- Added the **Your birth or adoption certificate** task-list section, after
  Statutory declarations, and its upload page
  (`/upload/birth-or-adoption-certificate`).
- Reused the existing upload behaviour and validation:
  - JPG, BMP, PNG, TIF and PDF files only;
  - maximum file size 10MB;
  - existing storage, virus scanning, removal and multi-file support.
- Added the uploaded certificate to **Check your answers**, including its filename.
- Conditional postal guidance:
  - Check your answers, confirmation and completed-application email content no
    longer ask an applicant to post a certificate they have uploaded;
  - the existing postal certificate instructions remain when no certificate is
    uploaded.
- Updated the admin application view and generated application PDFs so
  **Documents to post** includes the certificate only when it has not been uploaded.
- Kept `admin/templates/applications/application.html` in sync with the public
  PDF-bundle template, as required by `test_pdf_bundle_templates_in_sync.py`.
- Added approved Welsh translations for all new public-facing content.

### Acceptance criteria coverage
- [x] Applicant can reach the birth/adoption certificate section and upload a
      digital file.
- [x] A supported file is saved successfully.
- [x] An unsupported file is rejected with the existing valid-format error.
- [x] An uploaded certificate and filename are visible when reviewing the
      application.

### Out of scope / decisions
- The upload is **optional** and does not gate Submit and pay. Postal fallback
  remains for applicants who cannot or do not upload a certificate.
- No GLiMR system change: the existing admin attachment ZIP/PDF/manual GLiMR
  handoff already includes the `birthOrAdoptionCertificate` upload section.
- No changes to the historic mandatory One Login flow from TPET-398: that ticket
  is `Closed` with resolution `Withdrawn` and does not override TPET-831.
- No cleanup of `grc/templates/applications/application_user.html`; it is an
  unused duplicate unrelated to the live render paths.

### Testing
- New unit tests:
  `tests/grc/unit/test_birth_or_adoption_certificate_upload.py`
- New integration tests:
  `tests/grc/integration/test_birth_or_adoption_certificate_upload.py`
- New admin regression tests:
  `tests/admin/applications/test_view_application.py`
- Added journey 1 upload-flow coverage:
  `tests/end_to_end_tests/journey_1/uploads/page_birth_or_adoption_certificate.py`
- Updated all affected English and Welsh E2E task-list count assertions.
- Targeted Welsh follow-up run (unit + integration): **17 passed**.
- Focused suite including admin regression and PDF-template-sync tests:
  **22 passed**.
- `pybabel compile -d grc/translations` passed.
- Full non-E2E CI-equivalent suite was compared against a stashed baseline: no
  new failures were introduced; known wider-suite environment failures were
  identical on both trees.
- Manually verified in a disposable local browser session: task-list entry,
  upload-page content, unsupported-file error, uploaded-certificate confirmation
  without postal guidance, and no-upload confirmation with postal fallback.