### PR TITLE
TPET-832 Add digital support information

### DIFF
--- a/grc/templates/one-login/start.html
+++ b/grc/templates/one-login/start.html
@@ -15,6 +15,30 @@
                 {{ _('Start or return to an application') }}
             </h1>
 
+            <section id="digital-support" aria-labelledby="digital-support-heading">
+                <h2 class="govuk-heading-m" id="digital-support-heading">
+                    {{ _('Get help applying online') }}
+                </h2>
+
+                <p class="govuk-body">
+                    {{ _('If you do not have access to the internet or do not feel confident using it, contact We Are Group.') }}
+                </p>
+
+                <p class="govuk-body">
+                    <a href="https://www.wearegroup.com/digital_support" class="govuk-link">We Are Group</a><br>
+                    <a href="mailto:support@wearegroup.com" class="govuk-link">support@wearegroup.com</a><br>
+                    {{ _('Telephone:') }} <a href="tel:+443300160051" class="govuk-link">03300 160 051</a><br>
+                    {{ pgettext('DIGITAL_SUPPORT', 'Monday to Friday, 9am to 5pm') }}<br>
+                    {{ _('Closed on bank holidays') }}<br>
+                    {{ _('Text FORM to 60777 and someone will call you back') }}<br>
+                    {% if g.lang_code == 'cy' %}
+                        <a href="https://www.gov.uk/costau-galwadau" class="govuk-link">{{ _('Find out about call charges') }}</a>
+                    {% else %}
+                        <a href="https://www.gov.uk/call-charges" class="govuk-link">{{ _('Find out about call charges') }}</a>
+                    {% endif %}
+                </p>
+            </section>
+
             <p class="govuk-body">
               {{ _("You’ll need a <a href=\"https://www.gov.uk/using-your-gov-uk-one-login/services\" target=\"_blank\" class=\"govuk-link\">GOV.UK One Login</a> to start a new application or return to your application that was started with GOV.UK One Login.") | safe }}
             </p>

--- a/grc/translations/cy/LC_MESSAGES/messages.po
+++ b/grc/translations/cy/LC_MESSAGES/messages.po
@@ -4621,13 +4621,50 @@ msgstr ""
 msgid "Start or return to an application"
 msgstr "Dechrau cais newydd neu ddychwelyd i gais"
 
+#. TPET-832: WLU-approved translation.
+#: grc/templates/one-login/start.html
+msgid "Get help applying online"
+msgstr "Cael cymorth i wneud cais ar-lein"
+
+#. TPET-832: WLU-approved translation.
+#: grc/templates/one-login/start.html
+msgid "If you do not have access to the internet or do not feel confident using it, contact We Are Group."
+msgstr "Os nad oes gennych fynediad i'r rhyngrwyd neu os nad ydych yn teimlo'n hyderus yn ei ddefnyddio, cysylltwch â We Are Group."
+
+#. TPET-832: Reuses the existing approved translation for "Telephone".
+#: grc/templates/one-login/start.html
+msgid "Telephone:"
+msgstr "Rhif ffôn:"
+
+#. TPET-832: WLU clarification pending; the existing catalogue translation
+#. says Friday closes at 4.30pm, while this English string says 5pm.
+#: grc/templates/one-login/start.html
+msgctxt "DIGITAL_SUPPORT"
+msgid "Monday to Friday, 9am to 5pm"
+msgstr ""
+
+#. TPET-832: WLU-approved translation.
+#: grc/templates/one-login/start.html
+msgid "Closed on bank holidays"
+msgstr "Ar gau ar wyliau banc"
+
+#. TPET-832: WLU-approved translation. Keep FORM and 60777 unchanged.
+#: grc/templates/one-login/start.html
+msgid "Text FORM to 60777 and someone will call you back"
+msgstr "Tecstiwch FORM i 60777 a bydd rhywun yn eich ffonio'n ôl"
+
+#. TPET-832: WLU-approved translation.
+#: grc/templates/one-login/start.html
+msgid "Find out about call charges"
+msgstr "Rhagor o wybodaeth am gostau galwadau"
+
 #: grc/templates/one-login/start.html
 msgid "You’ll need a <a href=\"https://www.gov.uk/using-your-gov-uk-one-login/services\" target=\"_blank\" class=\"govuk-link\">GOV.UK One Login</a> to start a new application or return to your application that was started with GOV.UK One Login."
 msgstr "Bydd arnoch angen cyfrif <a href=\"https://www.gov.uk/apply-gender-recognition-certificate\" target=\"_blank\" class=\"govuk-link\">GOV.UK One Login</a> er mwyn dechrau cais newydd neu ddychwelyd i’ch cais a ddechreuwyd gyda One Login GOV.UK."
 
 #: grc/templates/one-login/start.html
 msgid "If this is your first time using this service, we will give you a reference number. You will need this if you return to your application."
-msgstr Os mai hwn yw’r tro cyntaf i chi ddefnyddio’r gwasanaeth hwn, byddwn yn rhoi cyfeirnod i chi. Byddwch angen hwn os byddwch yn dychwelyd i’ch cais."
+msgstr "Os mai hwn yw’r tro cyntaf i chi ddefnyddio’r gwasanaeth hwn, byddwn yn rhoi cyfeirnod i chi. Byddwch angen hwn os byddwch yn dychwelyd i’ch cais."
 
 #: grc/templates/one-login/start.html
 msgid "If you are returning to your application which was not started with GOV.UK One Login, you will also need to enter your email address and security code."

--- a/messages.pot
+++ b/messages.pot
@@ -4093,6 +4093,35 @@ msgid "Start or return to an application"
 msgstr ""
 
 #: grc/templates/one-login/start.html
+msgid "Get help applying online"
+msgstr ""
+
+#: grc/templates/one-login/start.html
+msgid "If you do not have access to the internet or do not feel confident using it, contact We Are Group."
+msgstr ""
+
+#: grc/templates/one-login/start.html
+msgid "Telephone:"
+msgstr ""
+
+#: grc/templates/one-login/start.html
+msgctxt "DIGITAL_SUPPORT"
+msgid "Monday to Friday, 9am to 5pm"
+msgstr ""
+
+#: grc/templates/one-login/start.html
+msgid "Closed on bank holidays"
+msgstr ""
+
+#: grc/templates/one-login/start.html
+msgid "Text FORM to 60777 and someone will call you back"
+msgstr ""
+
+#: grc/templates/one-login/start.html
+msgid "Find out about call charges"
+msgstr ""
+
+#: grc/templates/one-login/start.html
 msgid "You’ll need a <a href=\"https://www.gov.uk/using-your-gov-uk-one-login/services\" target=\"_blank\" class=\"govuk-link\">GOV.UK One Login</a> to start a new application or return to your application that was started with GOV.UK One Login."
 msgstr ""
 
@@ -4154,6 +4183,4 @@ msgstr ""
 
 #: grc/templates/start-application/email-address.html
 msgid "Your email address has not been validated"
-msgstr "Uwchlwythwch sgan neu lun o ansawdd da o’r dystysgrif."
-
-
+msgstr ""

--- a/tests/end_to_end_tests/journey_1/login_and_confirmation/section.py
+++ b/tests/end_to_end_tests/journey_1/login_and_confirmation/section.py
@@ -13,6 +13,20 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     assert await page.inner_text('a.govuk-header__link.govuk-header__service-name') == 'Apply for a Gender Recognition Certificate'
     await asserts.h1('Start or return to an application')
     await asserts.number_of_errors(0)
+    assert await page.inner_text('#digital-support-heading') == 'Get help applying online'
+    assert await page.locator(
+        '#digital-support a[href="https://www.wearegroup.com/digital_support"]'
+    ).count() == 1
+    assert await page.locator(
+        '#digital-support a[href="mailto:support@wearegroup.com"]'
+    ).count() == 1
+    assert await page.locator(
+        '#digital-support a[href="tel:+443300160051"]'
+    ).count() == 1
+    assert await page.locator(
+        '#digital-support a[href="https://www.gov.uk/call-charges"]'
+    ).count() == 1
+    assert await page.locator('#digital-support a[target="_blank"]').count() == 0
 
     # Select no options, see error message
     await helpers.click_button('Continue')

--- a/tests/end_to_end_tests/journey_cy/login_and_confirmation/section.py
+++ b/tests/end_to_end_tests/journey_cy/login_and_confirmation/section.py
@@ -20,6 +20,28 @@ async def run_checks_on_section(page: Page, asserts: AssertHelpers, helpers: Pag
     await helpers.click_button('Cymraeg')
     assert await page.inner_text('a.govuk-header__link.govuk-header__service-name') == 'Gwneud cais am Dystysgrif Cydnabod Rhywedd'
     await asserts.h1('Dechrau cais newydd neu ddychwelyd i gais')
+    assert await page.inner_text('#digital-support-heading') == 'Cael cymorth i wneud cais ar-lein'
+    digital_support_text = await page.inner_text('#digital-support')
+    assert "Os nad oes gennych fynediad i'r rhyngrwyd neu os nad ydych yn teimlo'n hyderus yn ei ddefnyddio, cysylltwch â We Are Group." in digital_support_text
+    assert 'Rhif ffôn:' in digital_support_text
+    assert 'Monday to Friday, 9am to 5pm' in digital_support_text
+    assert 'dydd Gwener 9am i 4.30pm' not in digital_support_text
+    assert 'Ar gau ar wyliau banc' in digital_support_text
+    assert "Tecstiwch FORM i 60777 a bydd rhywun yn eich ffonio'n ôl" in digital_support_text
+    assert 'Rhagor o wybodaeth am gostau galwadau' in digital_support_text
+    assert await page.locator(
+        '#digital-support a[href="https://www.wearegroup.com/digital_support"]'
+    ).count() == 1
+    assert await page.locator(
+        '#digital-support a[href="mailto:support@wearegroup.com"]'
+    ).count() == 1
+    assert await page.locator(
+        '#digital-support a[href="tel:+443300160051"]'
+    ).count() == 1
+    assert await page.locator(
+        '#digital-support a[href="https://www.gov.uk/costau-galwadau"]'
+    ).count() == 1
+    assert await page.locator('#digital-support a[target="_blank"]').count() == 0
 
     # Choose the "Start a new application" option
     await helpers.check_radio(field='new_application', value=True)

--- a/tests/grc/integration/start_application/test_index.py
+++ b/tests/grc/integration/start_application/test_index.py
@@ -1,12 +1,81 @@
-from unittest.mock import patch
+import pytest
+from flask.sessions import SecureCookieSessionInterface
+
+
+@pytest.fixture()
+def client(app):
+    app.config['SECRET_KEY'] = 'test-secret-key'
+    app.session_interface = SecureCookieSessionInterface()
+    return app.test_client()
 
 
 class TestIndex:
+    def assert_english_digital_support_content(self, response):
+        assert 'Get help applying online' in response.text
+        assert (
+            'If you do not have access to the internet or do not feel confident using it, contact We Are Group.'
+            in response.text
+        )
+        assert 'We Are Group' in response.text
+        assert 'support@wearegroup.com' in response.text
+        assert 'Telephone:' in response.text
+        assert '03300 160 051' in response.text
+        assert 'Monday to Friday, 9am to 5pm' in response.text
+        assert 'Closed on bank holidays' in response.text
+        assert 'Text FORM to 60777 and someone will call you back' in response.text
+        assert 'Find out about call charges' in response.text
+
+    def assert_digital_support_links(self, response, call_charges_url='https://www.gov.uk/call-charges'):
+        digital_support_html = response.text.split('<section id="digital-support"')[1].split('</section>')[0]
+        assert (
+            '<a href="https://www.wearegroup.com/digital_support" class="govuk-link">We Are Group</a>'
+            in digital_support_html
+        )
+        assert (
+            '<a href="mailto:support@wearegroup.com" class="govuk-link">support@wearegroup.com</a>'
+            in digital_support_html
+        )
+        assert (
+            '<a href="tel:+443300160051" class="govuk-link">03300 160 051</a>'
+            in digital_support_html
+        )
+        assert f'<a href="{call_charges_url}" class="govuk-link">' in digital_support_html
+        assert 'target=' not in digital_support_html
+
+    def assert_welsh_digital_support_content(self, response):
+        assert 'Cael cymorth i wneud cais ar-lein' in response.text
+        assert (
+            "Os nad oes gennych fynediad i'r rhyngrwyd neu os nad ydych yn teimlo'n hyderus yn ei ddefnyddio, "
+            'cysylltwch â We Are Group.' in response.text
+        )
+        assert 'Rhif ffôn:' in response.text
+        assert 'Monday to Friday, 9am to 5pm' in response.text
+        assert 'dydd Gwener 9am i 4.30pm' not in response.text
+        assert 'Ar gau ar wyliau banc' in response.text
+        assert "Tecstiwch FORM i 60777 a bydd rhywun yn eich ffonio'n ôl" in response.text
+        assert 'Rhagor o wybodaeth am gostau galwadau' in response.text
+
     def test_index(self, app, client):
         with app.app_context():
             response = client.get('/')
             assert response.status_code == 200
             assert 'Start or return to an application' in response.text
+            self.assert_english_digital_support_content(response)
+            self.assert_digital_support_links(response)
+
+    def test_index_welsh_uses_language_neutral_support_values_and_welsh_call_charges(self, app, client):
+        with app.app_context():
+            with client.session_transaction() as session:
+                session['lang_code'] = 'cy'
+
+            response = client.get('/')
+
+            assert response.status_code == 200
+            self.assert_welsh_digital_support_content(response)
+            assert 'We Are Group' in response.text
+            assert 'support@wearegroup.com' in response.text
+            assert '03300 160 051' in response.text
+            self.assert_digital_support_links(response, call_charges_url='https://www.gov.uk/costau-galwadau')
 
     def test_index_post_no_choice(self, app, client):
         with app.app_context():
@@ -14,6 +83,8 @@ class TestIndex:
             response = client.post('/', data=form_data)
             assert response.status_code == 200
             assert 'Start or return to an application' in response.text
+            self.assert_english_digital_support_content(response)
+            self.assert_digital_support_links(response)
             assert 'Select if you have already started an application' in response.text
 
     def test_index_start_application(self, app, client):


### PR DESCRIPTION
## TPET-832 — Add digital support information

Jira: https://tools.hmcts.net/jira/browse/TPET-832

### What & why
Applicants who do not have internet access or do not feel confident applying
online need a clear way to obtain assisted digital support.

TPET-832 adds the current We Are Group support information to the existing
start/return page (`/`), making it visible before an applicant starts or
returns to an application.

### Changes
- Added an **always-visible digital support section** immediately after the
  start-page H1 (`grc/templates/one-login/start.html`).
- Added the current We Are Group support details:
  - provider website
  - `support@wearegroup.com`
  - `03300 160 051`
  - Monday-to-Friday opening hours
  - bank-holiday closure information
  - text `FORM` to `60777` callback service
  - GOV.UK call-charges guidance
- Added language-specific call-charges links:
  - English: `https://www.gov.uk/call-charges`
  - Welsh: `https://www.gov.uk/costau-galwadau`
- Added the WLU-approved Welsh translations returned for TPET-832.
- Reused the existing approved Welsh telephone label: `Rhif ffôn:`.
- Added a `DIGITAL_SUPPORT` gettext context for the opening-hours string. This
  prevents an unrelated existing Welsh translation, which says Friday closes
  at 4:30pm, from being applied to the We Are Group 5pm closing time.
- Added integration and E2E assertions covering the English and Welsh content,
  fixed contact details, link destinations and same-tab behaviour.
- Corrected existing malformed Welsh catalogue/POT entries encountered while
  compiling the translations.

### Acceptance criteria coverage
- [x] Digital-support information is displayed on the start/return page.
- [x] Applicants can access the We Are Group support website.
- [x] Applicants can contact support by email or telephone.
- [x] Applicants can request a callback by texting `FORM` to `60777`.
- [x] Opening hours and bank-holiday information are displayed.
- [x] Call-charges guidance uses the correct English or Welsh GOV.UK link.
- [x] Support links open in the same tab.
- [x] Returned WLU translations are displayed in the Welsh journey.

### Out of scope / decisions
- No new route, separate support page or acknowledgement step was introduced.
- No feature flag, analytics event, JavaScript, CSS, database model or
  migration was required.
- Provider names, URLs, email addresses, telephone numbers and the
  `FORM`/`60777` values remain fixed rather than being translated.
- The Welsh weekday-hours line currently falls back to the correct English
  wording. The existing Welsh catalogue wording describes different Friday
  opening hours and has deliberately not been reused.
- WLU confirmation is still required for the Welsh weekday-hours wording and
  whether the English-only We Are Group destination needs a qualifier.

### Testing
- Updated integration tests:
  `tests/grc/integration/start_application/test_index.py`
- Updated English E2E coverage:
  `tests/end_to_end_tests/journey_1/login_and_confirmation/section.py`
- Updated Welsh E2E coverage:
  `tests/end_to_end_tests/journey_cy/login_and_confirmation/section.py`
- Focused integration run: **5 passed**.
- Welsh translation catalogue compiled successfully.
- Python syntax checks and `git diff --check` passed.
- Launched the full local Docker stack using the repository-external launcher.
- Manually verified through Chrome MCP:
  - the complete English support section
  - the returned Welsh translations
  - provider, email and telephone links
  - English and Welsh call-charges destinations
  - the safe English fallback for the unconfirmed Welsh opening-hours string