### PR TITLE
TPET-865 Upgrade Pillow to 12.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ waitress==3.0.0
 Werkzeug==3.0.4
 WTForms==3.1.2
 xhtml2pdf==0.2.16
-pillow==10.4.0
+pillow==12.3.0
 PyMuPDF==1.24.11
 pyClamd==0.4.0
 cryptography==45.0.6


### PR DESCRIPTION
## TPET-865 — Upgrade Pillow to 12.3.0

Jira: https://tools.hmcts.net/jira/browse/TPET-865

### What & why

Upgrade Pillow from 10.4.0 to 12.3.0 to remediate upload and file-processing vulnerabilities.

### Testing

- Existing upload and file-processing tests passed.
- All application images built successfully.
- Chrome verified JPG, PNG, TIFF, BMP and PDF uploads.
- Invalid and oversized file validation remains unchanged.
- PR SCA and Dependabot alert closure to be confirmed after push.