### PR TITLE
TPET-864 Upgrade runtime dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.4
 jmespath==1.0.1
 jsonpickle~=3.3.0
-Mako==1.3.5
+Mako==1.3.12
 MarkupSafe==2.1.5
 memory_profiler==0.61.0
 notifications-python-client==10.0.0
@@ -57,8 +57,8 @@ SQLAlchemy==2.0.36
 SQLAlchemy-Utils==0.41.2
 toml==0.10.2
 urllib3==1.26.18
-waitress==3.0.0
-Werkzeug==3.0.4
+waitress==3.0.2
+Werkzeug==3.1.8
 WTForms==3.1.2
 xhtml2pdf==0.2.16
 pillow==10.4.0


### PR DESCRIPTION
## TPET-864 — Upgrade runtime dependencies

Jira: https://tools.hmcts.net/jira/browse/TPET-864

### What & why
Upgrade Waitress, Werkzeug and Mako to patched releases to remediate runtime security vulnerabilities.

### Changes
- Upgraded Waitress from 3.0.0 to 3.0.2.
- Upgraded Werkzeug from 3.0.4 to 3.1.8.
- Upgraded Mako from 1.3.5 to 1.3.12.
- No application code, migrations, content or translations changed.

### Testing
- `pip check` passed with the target versions installed.
- Existing Python 3.12 suite passed: **383 tests**.
- Alembic upgrade/current/check and Mako revision rendering passed.
- Legacy Werkzeug scrypt and PBKDF2 password hashes remain valid.
- Public, Admin, Dashboard and JWKS images built and started successfully.
- Local Jenkins pipeline passed, including tests and all four image builds.
- Chrome verified public form/session/upload handling, Admin sign-in and pages, Dashboard rendering, and JWKS output.
- Live GitHub advisory queries returned no applicable advisories for the target versions.
- PR SCA and Dependabot alert closure to be confirmed after push.
